### PR TITLE
feat(auth): JWT architecture overhaul — dual-audience tokens + user auth flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,361 @@
+# CLAUDE.md — PrismaCV Backend
+
+## Quick Reference
+
+```bash
+# Development
+npm run start:dev          # NestJS watch mode
+npm run build              # nest build (tsc)
+npm run lint               # eslint --fix
+npm run test               # jest (unit tests)
+npm run test:e2e           # requires postgres on :5433, runs migrations + seed
+npm run test:cov           # jest --coverage
+
+# Database
+npm run db:migrate         # prisma migrate dev
+npm run db:deploy          # prisma migrate deploy
+npm run db:generate        # prisma generate
+docker-compose up -d postgres_test   # spin up test DB on port 5433
+
+# Validate before committing (always do this)
+npx nest build && npx eslint . && npx jest --no-cache
+```
+
+## Architecture Overview
+
+NestJS 10 + Prisma + PostgreSQL. REST API with Swagger docs at `/api/v1/docs`.
+
+```
+src/
+├── main.ts                    # Bootstrap: helmet, compression, CORS, ValidationPipe, Swagger
+├── app.module.ts              # Root module, global APP_GUARD = JwtAdminAuthGuard
+├── config/                    # AppConfig factory, PrismaService, logger, feature-flags
+├── common/                    # Cross-cutting: decorators, guards, interceptors, filters
+├── modules/
+│   ├── auth/                  # Admin + user auth, JWT, OTP, password flows
+│   ├── email/                 # Nodemailer + HTML templates (global module)
+│   ├── health/                # GET /health
+│   ├── oauth/                 # Google + LinkedIn OAuth with provider pattern
+│   └── unleash/               # Feature flags
+└── shared/                    # Constants, utils, base classes, pagination DTO
+```
+
+### Module Dependency Graph
+
+```
+AppModule
+├── DatabaseModule (@Global)    → PrismaService
+├── EmailModule (@Global)       → EmailService
+├── AuthModule                  → AuthService, UsersService, OtpService, AuthMapper
+├── OAuthModule                 → imports AuthModule
+├── UnleashModule               → UnleashService
+└── HealthModule
+```
+
+### Request Lifecycle
+
+```
+HTTP Request
+  → helmet + compression
+  → CORS
+  → ValidationPipe (whitelist, forbidNonWhitelisted, transform, implicitConversion)
+  → JwtAdminAuthGuard (global; @Public() routes bypass)
+  → Controller method
+      → Mapper: DTO → entity
+      → Service: business logic + PrismaService
+      → Mapper: entity → response DTO
+  → TransformInterceptor wraps: { success: true, data, timestamp }
+  → LoggingInterceptor logs: method, url, duration
+  → HttpExceptionFilter catches errors: { statusCode, timestamp, path, method, message }
+```
+
+## Coding Patterns
+
+### File Naming
+
+`kebab-case.purpose.extension` — the purpose suffix is mandatory:
+
+```
+admin-login.request.dto.ts       # Request DTO
+user-login.response.dto.ts       # Response DTO
+auth.service.ts                  # Service
+auth.controller.ts               # Controller
+auth.mapper.ts                   # Mapper
+jwt-user.strategy.ts             # Passport strategy
+jwt-user-auth.guard.ts           # Guard
+user.entity.ts                   # Domain entity
+http-exception.filter.ts         # Exception filter
+transform.interceptor.ts         # Interceptor
+public.decorator.ts              # Decorator
+```
+
+### Controller Decorator Stacking Order
+
+```typescript
+@Public()                                          // 1. Access control
+@UseGuards(JwtUserAuthGuard)                       // 2. Specific guard (if needed)
+@Post('endpoint')                                  // 3. Route
+@HttpCode(HttpStatus.OK)                           // 4. HTTP metadata
+@Throttle({ default: { limit: 5, ttl: 300000 } }) // 5. Rate limiting
+@ApiBearerAuth('JWT-auth')                         // 6. Swagger auth
+@ApiOperation({ summary: '...', description: '...' }) // 7. Swagger docs
+@ApiBody({ type: RequestDto })
+@ApiResponse({ status: 200, type: ResponseDto })
+@ApiResponse({ status: 401, description: '...' })
+async method(@Body() dto: RequestDto): Promise<ResponseDto> { }
+```
+
+### DTOs
+
+**Request DTOs** use `class-validator` + `@ApiProperty`:
+```typescript
+export class AdminLoginRequestDto {
+  @ApiProperty({ example: 'admin@example.com' })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ example: 'admin123' })
+  @IsString()
+  @MinLength(4)
+  password: string;
+}
+```
+
+**Response DTOs** use only `@ApiProperty` (no validation decorators):
+```typescript
+export class AdminLoginResponseDto {
+  @ApiProperty({ description: 'JWT Access Token' })
+  accessToken: string;
+
+  @ApiProperty({ description: 'JWT Refresh Token' })
+  refreshToken: string;
+}
+```
+
+Request DTOs go in `dto/request/`, response DTOs go in `dto/response/`.
+
+### Entities
+
+Plain TypeScript classes extending `BaseEntity` (no Prisma annotations):
+```typescript
+export class User extends BaseEntity {
+  email: string;
+  password?: string;
+  name?: string;
+  role: UserRole;
+  isMasterAdmin: boolean = false;
+  // ...
+}
+```
+
+Prisma-to-entity mapping lives in `UsersService.prismaUserToEntity()`. Entities are the domain layer — never pass Prisma types across service boundaries.
+
+### Mappers
+
+`AuthMapper` is an `@Injectable()` service with method naming `[source]To[Target]`:
+- `signupRequestToEntity(dto)` — normalises email (lowercase + trim)
+- `loginRequestToCredentials(dto)`
+- `userToProfileResponse(user)`
+- `userToUserLoginResponse(user, tokens)`
+- `tokensToAdminLoginResponse(tokens)`
+
+All mapper methods throw `BadRequestException` on null input.
+
+Note: `AuthMapper` does **not** extend `BaseMapper`. `BaseMapper<TDto, TEntity>` exists in `shared/mappers/` but is unused — it's a template for future modules.
+
+### Error Handling
+
+Services throw NestJS HTTP exceptions directly:
+- `UnauthorizedException` — invalid credentials, expired tokens, insufficient permissions
+- `BadRequestException` — validation failures, policy violations
+- `ConflictException` — duplicate email (Prisma P2002)
+- `NotFoundException` — entity not found
+- `ForbiddenException` — role-based denial (master admin only)
+
+For security-sensitive flows (forgot-password), always return the same response to avoid user enumeration.
+
+### Logger Pattern
+
+```typescript
+private readonly logger = new Logger(ClassName.name);
+```
+
+Levels: `log` for happy-path, `warn` for failed validations, `error` for exceptions.
+
+### ID Generation
+
+All new records use UUIDv7 (`uuidv7` package) — time-ordered for DB index locality. The `User.id` column is `@db.Uuid`.
+
+## Auth Architecture
+
+### Dual-Audience JWT System
+
+Two Passport strategies with audience segregation:
+
+| Strategy | Name | Audience | Validates |
+|---|---|---|---|
+| `JwtAdminStrategy` | `jwt-admin` | `platform-admin` | `role === PLATFORM_ADMIN` (payload + DB) |
+| `JwtUserStrategy` | `jwt-user` | `user` | `role === REGULAR` (payload + DB) |
+
+**Token claims**: `sub` (userId), `email`, `role`, `isMasterAdmin`, `iss` (PrismaCV), `aud` (audience), `jti` (randomUUID), `exp`, `iat`. Algorithm: `HS256`.
+
+**Expiration**: Access token 15m, refresh token 7d.
+
+### Guard System
+
+- `JwtAdminAuthGuard` — **global** `APP_GUARD`. All routes require admin JWT unless marked `@Public()`.
+- `JwtUserAuthGuard` — applied per-route. **No** `@Public()` bypass — always authenticates.
+- Pattern for user-protected routes: `@Public()` (bypass global admin guard) + `@UseGuards(JwtUserAuthGuard)` (enforce user auth).
+
+### Auth Flows
+
+**Admin**: `POST /auth/admin/login` → tokens. `POST /auth/admin/create` (master admin only) → profile. `POST /auth/admin/refresh` → new tokens.
+
+**User**: `POST /auth/user/signup` → profile + OTP email. `POST /otp/verify-signup` → tokens. `POST /auth/user/login` → tokens (requires verified email). `POST /auth/user/refresh` → new tokens.
+
+**OAuth**: `GET /oauth/google` or `/oauth/linkedin` → callback → tokens (REGULAR users only).
+
+**Password reset**: `POST /auth/user/forgot-password` → OTP email. `POST /otp/verify-reset` → reset token. `POST /auth/user/reset-password` → done.
+
+### Security Details
+
+- Startup validation: `JWT_SECRET` and `JWT_REFRESH_SECRET` must be ≥ 32 chars (`OnModuleInit`)
+- Refresh tokens: bcrypt-hashed at rest, rotated on every use
+- OTP codes: bcrypt-hashed at rest, stored in separate `Otp` table
+- OAuth tokens: AES-256-GCM encrypted at rest (PBKDF2 key derivation)
+- Password reset tokens: bcrypt-hashed, stored in `AuthToken` table, 15min expiry
+- Rate limiting: 5 attempts per 5 minutes on OTP and forgot-password endpoints
+
+## Database
+
+PostgreSQL via Prisma ORM.
+
+### Models
+
+| Model | Purpose | Key Fields |
+|---|---|---|
+| `User` | Core user record | `id` (UUIDv7), `email`, `password?`, `role`, `isMasterAdmin`, `emailVerified`, `provider?`, `providerId?` |
+| `Otp` | OTP codes (bcrypt-hashed) | `userId`, `purpose` (SIGNUP/PASSWORD_RESET), `otpHash`, `attempts`, `expiresAt` |
+| `AuthToken` | Reset tokens (bcrypt-hashed) | `userId`, `purpose`, `tokenHash`, `expiresAt`, `usedAt` |
+| `LinkedinCvImport` | LinkedIn CV data | `userId`, `linkedinUrl`, JSON fields for profile/experience/education/skills |
+
+### Enums
+
+`UserRole`: `REGULAR`, `PLATFORM_ADMIN`
+`OtpPurpose`: `SIGNUP_EMAIL_VERIFICATION`, `PASSWORD_RESET`
+`AuthTokenPurpose`: `PASSWORD_RESET`, `EMAIL_VERIFICATION_LINK`, `ACCOUNT_ACTIVATION`
+
+### Docker
+
+```bash
+docker-compose up -d postgres       # dev DB on port 5432
+docker-compose up -d postgres_test  # test DB on port 5433
+```
+
+Credentials: `prismacv:password`. Dev DB: `prismacv_dev`. Test DB: `prismacv_test`.
+
+## Testing
+
+### Structure
+
+```
+test/
+├── e2e/                          # Full app integration tests (need DB)
+│   ├── jest-e2e.json
+│   └── *.e2e-spec.ts
+├── helpers/
+│   └── mock-user.helper.ts       # mockUser() and mockOtp() factories
+├── modules/                      # Unit tests mirroring src/modules/
+└── shared/
+```
+
+### Unit Test Patterns
+
+Use `@nestjs/testing` with `Test.createTestingModule`. Three mocking approaches:
+
+1. **`jest-mock-extended`** for Prisma: `mockDeep<PrismaService>()`
+2. **Manual mock objects** for services in controller tests:
+   ```typescript
+   { provide: AuthService, useValue: { adminLogin: jest.fn(), ... } }
+   ```
+3. **`jest.spyOn`** for partial mocking within service tests
+
+**ConfigService mock pattern:**
+```typescript
+{
+  provide: ConfigService,
+  useValue: {
+    get: jest.fn((key: string, defaultValue?: any) => {
+      const config: Record<string, any> = {
+        JWT_SECRET: '01234567890123456789012345678901',
+        JWT_REFRESH_SECRET: '01234567890123456789012345678901',
+        'app.name': 'PrismaCV',
+        'security.encryptionKey': '01234567890123456789012345678901',
+      };
+      return config[key] ?? defaultValue;
+    }),
+  },
+}
+```
+
+**Entity fixtures**: Use `Object.assign(new User(), { ... })` or `mockUser()` helper.
+
+### E2E Tests
+
+Require PostgreSQL on port 5433. Run via `npm run test:e2e` (auto-migrates and seeds). Set `UNLEASH_MOCK=true` and all OAuth env vars (can be dummy values). Use `supertest` for HTTP calls.
+
+### Test Naming Convention
+
+Files: `*.spec.ts` (unit), `*.e2e-spec.ts` (integration).
+
+Test structure:
+```typescript
+describe('ClassName', () => {
+  describe('methodName', () => {
+    it('should do X when Y', async () => { ... });
+    it('should throw Z when W', async () => { ... });
+  });
+});
+```
+
+## Config
+
+### Env Vars (critical)
+
+| Var | Required | Notes |
+|---|---|---|
+| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `JWT_SECRET` | Yes | ≥ 32 chars, validated at startup |
+| `JWT_REFRESH_SECRET` | Yes | ≥ 32 chars, validated at startup |
+| `MASTER_ADMIN_EMAIL` | For seed | Seeded admin account |
+| `MASTER_ADMIN_PASSWORD` | For seed | Seeded admin password |
+| `ENCRYPTION_KEY` | For OAuth | ≥ 32 chars, AES-256 key for OAuth token encryption |
+| `SMTP_USER` / `SMTP_PASS` | For email | If absent, email is disabled (logged warning) |
+| `LINKEDIN_CLIENT_ID` / `SECRET` | For OAuth | Required if LinkedIn OAuth enabled |
+| `GOOGLE_CLIENT_ID` / `SECRET` | For OAuth | Required if Google OAuth enabled |
+| `UNLEASH_MOCK` | For tests | Set `true` to skip real Unleash |
+
+### Path Aliases
+
+`@/*` maps to `src/*` (configured in both `tsconfig.json` and Jest `moduleNameMapper`).
+
+## TypeScript
+
+- Target: `ES2020`, Module: `CommonJS`
+- `strictNullChecks: false`, `noImplicitAny: false`
+- `@typescript-eslint/no-explicit-any: off`
+- ESLint: flat config (`eslint.config.js`) with TypeScript-ESLint + Prettier
+- No explicit return types required (`explicit-function-return-type: off`)
+
+## Conventions to Follow
+
+1. **Never bypass the mapper layer** — always convert DTOs ↔ entities through mapper methods
+2. **Never expose Prisma types outside services** — `UsersService.prismaUserToEntity()` is the boundary
+3. **Always validate at system boundaries** — use class-validator on request DTOs, trust internal types
+4. **Use NestJS HTTP exceptions** — don't create custom exception classes
+5. **Rate limit sensitive endpoints** — `@Throttle()` on OTP, password reset, login
+6. **Security-sensitive responses** — return generic success to prevent user enumeration
+7. **New entities get UUIDv7 IDs** — use `generateUuidv7()` from shared utils
+8. **Encrypt sensitive data at rest** — use `EncryptionUtil` for OAuth tokens, bcrypt for passwords/OTPs/tokens
+9. **All responses are wrapped** — `TransformInterceptor` adds `{ success, data, timestamp }` automatically
+10. **Test before commit** — run `npx nest build && npx eslint . && npx jest --no-cache`

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { WinstonModule } from 'nest-winston';
 import { APP_GUARD } from '@nestjs/core';
 
@@ -58,6 +58,10 @@ import { JwtAdminAuthGuard } from './modules/auth/guards/jwt-auth.guard';
     {
       provide: APP_GUARD,
       useClass: JwtAdminAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
     },
   ],
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,7 +18,7 @@ import { HealthModule } from './modules/health/health.module';
 import { EmailModule } from './modules/email/email.module';
 
 // Guards
-import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
+import { JwtAdminAuthGuard } from './modules/auth/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -57,7 +57,7 @@ import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
   providers: [
     {
       provide: APP_GUARD,
-      useClass: JwtAuthGuard,
+      useClass: JwtAdminAuthGuard,
     },
   ],
 })

--- a/src/common/interceptors/transform.interceptor.ts
+++ b/src/common/interceptors/transform.interceptor.ts
@@ -15,9 +15,10 @@ export interface Response<T> {
 }
 
 @Injectable()
-export class TransformInterceptor<T>
-  implements NestInterceptor<T, Response<T>>
-{
+export class TransformInterceptor<T> implements NestInterceptor<
+  T,
+  Response<T>
+> {
   intercept(
     context: ExecutionContext,
     next: CallHandler,

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -15,11 +15,10 @@ export const AppConfig = () => ({
   },
   jwt: {
     secret: process.env.JWT_SECRET,
-    expiresIn: process.env.JWT_EXPIRES_IN || JWT_EXPIRATION.DEFAULT_EXPIRES_IN,
+    expiresIn: process.env.JWT_EXPIRES_IN || JWT_EXPIRATION.ACCESS_TOKEN,
     refreshSecret: process.env.JWT_REFRESH_SECRET,
     refreshExpiresIn:
-      process.env.JWT_REFRESH_EXPIRES_IN ||
-      JWT_EXPIRATION.DEFAULT_REFRESH_EXPIRES_IN,
+      process.env.JWT_REFRESH_EXPIRES_IN || JWT_EXPIRATION.REFRESH_TOKEN,
   },
   bcrypt: {
     rounds: parseInt(process.env.BCRYPT_ROUNDS, 10) || 12,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -14,7 +14,6 @@ import {
   ApiOperation,
   ApiResponse,
   ApiBody,
-  ApiSecurity,
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
@@ -39,7 +38,6 @@ export class AuthController {
   @Public()
   @Post('admin/login')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
   @ApiOperation({
     summary: 'Platform admin authentication',
     description:
@@ -108,7 +106,6 @@ export class AuthController {
   @Public()
   @Post('admin/refresh')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
   @ApiOperation({
     summary: 'Refresh admin access token',
     description:
@@ -138,9 +135,9 @@ export class AuthController {
     }
 
     try {
-      // Call service with refresh token and convert result to response DTO
       const result = await this.authService.refreshToken(
         refreshTokenRequestDto.refreshToken,
+        'platform-admin',
       );
       return this.authMapper.userToAdminAuthResponse(
         result.user,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -106,11 +106,11 @@ export class AuthController {
   }
 
   @Public()
-  @Post('refresh')
+  @Post('admin/refresh')
   @HttpCode(HttpStatus.OK)
   @ApiSecurity({})
   @ApiOperation({
-    summary: 'Refresh access token',
+    summary: 'Refresh admin access token',
     description:
       'Refreshes JWT access token using a valid refresh token. Only available for PLATFORM_ADMIN users.',
   })

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -141,7 +141,7 @@ export class AuthController {
       );
       return this.authMapper.userToAdminAuthResponse(
         result.user,
-        result.tokens!,
+        result.tokens,
       );
     } catch (error) {
       if (error instanceof UnauthorizedException) {

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,7 +9,8 @@ import { AuthController } from './auth.controller';
 import { OtpController } from './otp.controller';
 import { UserAuthController } from './user-auth.controller';
 import { LocalStrategy } from './strategies/local.strategy';
-import { JwtStrategy } from './strategies/jwt.strategy';
+import { JwtAdminStrategy } from './strategies/jwt.strategy';
+import { JwtUserStrategy } from './strategies/jwt-user.strategy';
 import { UsersService } from './users.service';
 import { PrismaService } from '@/config/prisma.service';
 import { AuthMapper } from './mappers/auth.mapper';
@@ -28,7 +29,10 @@ import { EmailModule } from '@/modules/email/email.module';
           JWT_EXPIRATION.ACCESS_TOKEN;
         return {
           secret: configService.get<string>('JWT_SECRET'),
-          signOptions: { expiresIn: expiresIn as any },
+          signOptions: {
+            expiresIn: expiresIn as any,
+            algorithm: 'HS256',
+          },
         };
       },
       inject: [ConfigService],
@@ -40,7 +44,8 @@ import { EmailModule } from '@/modules/email/email.module';
     AuthService,
     OtpService,
     LocalStrategy,
-    JwtStrategy,
+    JwtAdminStrategy,
+    JwtUserStrategy,
     UsersService,
     PrismaService,
     ConfigService,
@@ -48,6 +53,6 @@ import { EmailModule } from '@/modules/email/email.module';
     AuthMapper,
   ],
   controllers: [AuthController, OtpController, UserAuthController],
-  exports: [AuthService, OtpService],
+  exports: [AuthService, OtpService, UsersService],
 })
 export class AuthModule {}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -20,7 +20,10 @@ import { ForgotPasswordResponseDto } from './dto/response/forgot-password.respon
 import { ResetPasswordResponseDto } from './dto/response/rese-password.response.dto';
 import { ChangePasswordResponseDto } from './dto/response/change-password.response.dto';
 import { VerifyResetOtpResponseDto } from './dto/response/verify-reset-otp.response.dto';
-import { JWT_EXPIRATION } from '@/shared/constants/jwt.constants';
+import {
+  JWT_EXPIRATION,
+  JWT_MIN_SECRET_LENGTH,
+} from '@/shared/constants/jwt.constants';
 import {
   generateResetToken,
   hashResetToken,
@@ -45,12 +48,12 @@ export class AuthService implements OnModuleInit {
     const secret = this.configService.get<string>('JWT_SECRET');
     const refreshSecret = this.configService.get<string>('JWT_REFRESH_SECRET');
 
-    if (!secret || secret.length < 32) {
+    if (!secret || secret.length < JWT_MIN_SECRET_LENGTH) {
       throw new Error(
         'JWT_SECRET is not set or too short (minimum 32 characters).',
       );
     }
-    if (!refreshSecret || refreshSecret.length < 32) {
+    if (!refreshSecret || refreshSecret.length < JWT_MIN_SECRET_LENGTH) {
       throw new Error(
         'JWT_REFRESH_SECRET is not set or too short (minimum 32 characters).',
       );

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -172,8 +172,7 @@ export class AuthService implements OnModuleInit {
   }
 
   /**
-   * User login - validates credentials and ensures REGULAR role
-   * Returns user profile only (no tokens)
+   * User login - validates credentials, enforces email verification, and issues JWT tokens
    */
   async userLogin(
     credentials: AuthCredentials,
@@ -268,8 +267,12 @@ export class AuthService implements OnModuleInit {
 
   async refreshToken(
     refreshToken: string,
+    expectedAudience: 'platform-admin' | 'user',
   ): Promise<{ user: User; tokens?: TokenPair | undefined }> {
-    const decoded = await this.decodeRefreshToken(refreshToken);
+    const decoded = await this.decodeRefreshToken(
+      refreshToken,
+      expectedAudience,
+    );
     const user = await this.usersService.findById(decoded.sub);
     if (!user || !user.refreshToken) {
       this.logger.warn(
@@ -290,15 +293,12 @@ export class AuthService implements OnModuleInit {
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
 
-    const audience =
-      user.role === UserRole.PLATFORM_ADMIN ? 'platform-admin' : 'user';
-
     const tokenData = await this.getTokens(
       user.id,
       user.email,
       user.role,
       user.isMasterAdmin,
-      audience,
+      expectedAudience,
     );
     await this.updateRefreshToken(user.id, tokenData.refreshToken);
 
@@ -322,7 +322,8 @@ export class AuthService implements OnModuleInit {
   ) {
     const issuer = this.configService.get<string>('app.name', 'PrismaCV');
     const jwtSecret = this.configService.get<string>('JWT_SECRET');
-    const jwtRefreshSecret = this.configService.get<string>('JWT_REFRESH_SECRET');
+    const jwtRefreshSecret =
+      this.configService.get<string>('JWT_REFRESH_SECRET');
 
     const [accessToken, refreshToken] = await Promise.all([
       this.jwtService.signAsync(
@@ -369,10 +370,16 @@ export class AuthService implements OnModuleInit {
     });
   }
 
-  async decodeRefreshToken(token: string) {
+  async decodeRefreshToken(
+    token: string,
+    expectedAudience: 'platform-admin' | 'user',
+  ) {
     try {
       return await this.jwtService.verifyAsync(token, {
         secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
+        audience: expectedAudience,
+        issuer: this.configService.get<string>('app.name', 'PrismaCV'),
+        algorithms: ['HS256'],
       });
     } catch {
       this.logger.warn('Token verification failed: invalid or expired token');

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -4,9 +4,11 @@ import {
   Logger,
   ConflictException,
   BadRequestException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
 import * as bcrypt from 'bcryptjs';
 import { UsersService } from './users.service';
 import { OtpService } from './otp.service';
@@ -28,7 +30,7 @@ import { PrismaService } from '@/config/prisma.service';
 import { AuthTokenPurpose, OtpPurpose } from '@prisma/client';
 
 @Injectable()
-export class AuthService {
+export class AuthService implements OnModuleInit {
   constructor(
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
@@ -38,6 +40,22 @@ export class AuthService {
     private readonly prisma: PrismaService,
     private readonly logger: Logger = new Logger(AuthService.name),
   ) {}
+
+  onModuleInit() {
+    const secret = this.configService.get<string>('JWT_SECRET');
+    const refreshSecret = this.configService.get<string>('JWT_REFRESH_SECRET');
+
+    if (!secret || secret.length < 32) {
+      throw new Error(
+        'JWT_SECRET is not set or too short (minimum 32 characters).',
+      );
+    }
+    if (!refreshSecret || refreshSecret.length < 32) {
+      throw new Error(
+        'JWT_REFRESH_SECRET is not set or too short (minimum 32 characters).',
+      );
+    }
+  }
 
   async validateUser(credentials: AuthCredentials): Promise<User | null> {
     const user = await this.usersService.findByEmail(credentials.email);
@@ -88,12 +106,12 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    // Generate tokens for admin
     const tokenData = await this.getTokens(
       user.id,
       user.email,
       user.role,
       user.isMasterAdmin,
+      'platform-admin',
     );
     await this.updateRefreshToken(user.id, tokenData.refreshToken);
 
@@ -157,7 +175,9 @@ export class AuthService {
    * User login - validates credentials and ensures REGULAR role
    * Returns user profile only (no tokens)
    */
-  async userLogin(credentials: AuthCredentials): Promise<{ user: User }> {
+  async userLogin(
+    credentials: AuthCredentials,
+  ): Promise<{ user: User; tokens: TokenPair }> {
     const user = await this.validateUser(credentials);
     if (!user) {
       this.logger.warn(
@@ -166,7 +186,6 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    // Ensure user has REGULAR role
     if (user.role !== UserRole.REGULAR) {
       this.logger.warn(
         `User login failed: user is not REGULAR, email=${user.email}, role=${user.role}`,
@@ -174,11 +193,33 @@ export class AuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    if (!user.emailVerified) {
+      this.logger.warn(
+        `User login failed: email not verified, email=${user.email}`,
+      );
+      throw new UnauthorizedException(
+        'Email address not verified. Please check your inbox for the verification OTP.',
+      );
+    }
+
+    const tokenData = await this.getTokens(
+      user.id,
+      user.email,
+      user.role,
+      user.isMasterAdmin,
+      'user',
+    );
+    await this.updateRefreshToken(user.id, tokenData.refreshToken);
+
+    const tokens = new TokenPair();
+    tokens.accessToken = tokenData.accessToken;
+    tokens.refreshToken = tokenData.refreshToken;
+
     this.logger.log(
       `User login successful: email=${user.email}, userId=${user.id}`,
     );
 
-    return { user };
+    return { user, tokens };
   }
 
   /**
@@ -249,13 +290,15 @@ export class AuthService {
       throw new UnauthorizedException('Invalid or expired refresh token');
     }
 
-    // Maintain role-based token generation logic
-    // Tokens contain role information from getTokens method
+    const audience =
+      user.role === UserRole.PLATFORM_ADMIN ? 'platform-admin' : 'user';
+
     const tokenData = await this.getTokens(
       user.id,
       user.email,
       user.role,
       user.isMasterAdmin,
+      audience,
     );
     await this.updateRefreshToken(user.id, tokenData.refreshToken);
 
@@ -275,7 +318,12 @@ export class AuthService {
     email: string,
     role: string,
     isMasterAdmin: boolean,
+    audience: 'platform-admin' | 'user',
   ) {
+    const issuer = this.configService.get<string>('app.name', 'PrismaCV');
+    const jwtSecret = this.configService.get<string>('JWT_SECRET');
+    const jwtRefreshSecret = this.configService.get<string>('JWT_REFRESH_SECRET');
+
     const [accessToken, refreshToken] = await Promise.all([
       this.jwtService.signAsync(
         {
@@ -283,10 +331,14 @@ export class AuthService {
           email,
           role,
           isMasterAdmin,
+          iss: issuer,
+          aud: audience,
+          jti: randomUUID(),
         },
         {
-          secret: process.env.JWT_SECRET,
+          secret: jwtSecret,
           expiresIn: JWT_EXPIRATION.ACCESS_TOKEN,
+          algorithm: 'HS256',
         },
       ),
       this.jwtService.signAsync(
@@ -295,18 +347,19 @@ export class AuthService {
           email,
           role,
           isMasterAdmin,
+          iss: issuer,
+          aud: audience,
+          jti: randomUUID(),
         },
         {
-          secret: process.env.JWT_REFRESH_SECRET,
+          secret: jwtRefreshSecret,
           expiresIn: JWT_EXPIRATION.REFRESH_TOKEN,
+          algorithm: 'HS256',
         },
       ),
     ]);
 
-    return {
-      accessToken,
-      refreshToken,
-    };
+    return { accessToken, refreshToken };
   }
 
   async updateRefreshToken(userId: string, refreshToken: string) {
@@ -319,7 +372,7 @@ export class AuthService {
   async decodeRefreshToken(token: string) {
     try {
       return await this.jwtService.verifyAsync(token, {
-        secret: process.env.JWT_REFRESH_SECRET,
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
       });
     } catch {
       this.logger.warn('Token verification failed: invalid or expired token');

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -268,7 +268,7 @@ export class AuthService implements OnModuleInit {
   async refreshToken(
     refreshToken: string,
     expectedAudience: 'platform-admin' | 'user',
-  ): Promise<{ user: User; tokens?: TokenPair | undefined }> {
+  ): Promise<{ user: User; tokens: TokenPair }> {
     const decoded = await this.decodeRefreshToken(
       refreshToken,
       expectedAudience,
@@ -277,6 +277,17 @@ export class AuthService implements OnModuleInit {
     if (!user || !user.refreshToken) {
       this.logger.warn(
         `Token refresh failed: user not found or no refresh token, userId=${decoded.sub}`,
+      );
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    const expectedRole =
+      expectedAudience === 'platform-admin'
+        ? UserRole.PLATFORM_ADMIN
+        : UserRole.REGULAR;
+    if (user.role !== expectedRole) {
+      this.logger.warn(
+        `Token refresh failed: role/audience mismatch, userId=${user.id}, role=${user.role}, expectedAudience=${expectedAudience}`,
       );
       throw new UnauthorizedException('Invalid or expired refresh token');
     }

--- a/src/modules/auth/dto/request/change-password.request.dto.ts
+++ b/src/modules/auth/dto/request/change-password.request.dto.ts
@@ -1,15 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MinLength, IsUUID } from 'class-validator';
+import { IsString, MinLength } from 'class-validator';
 
 export class ChangePasswordRequestDto {
-  @ApiProperty({
-    example: '01234567-89ab-cdef-0123-456789abcdef',
-    description: 'User ID obtained from login response',
-  })
-  @IsString()
-  @IsUUID()
-  userId: string;
-
   @ApiProperty({
     example: 'OldPassword123',
     description: 'Current password of the user',

--- a/src/modules/auth/dto/response/otp-verification.response.dto.ts
+++ b/src/modules/auth/dto/response/otp-verification.response.dto.ts
@@ -13,4 +13,10 @@ export class OtpVerificationResponseDto {
     type: UserProfileResponseDto,
   })
   user: UserProfileResponseDto;
+
+  @ApiProperty({ description: 'JWT access token (15 min TTL)' })
+  accessToken: string;
+
+  @ApiProperty({ description: 'JWT refresh token (7 day TTL)' })
+  refreshToken: string;
 }

--- a/src/modules/auth/dto/response/user-login.response.dto.ts
+++ b/src/modules/auth/dto/response/user-login.response.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { UserAuthResponseDto } from '@/modules/auth/dto/response/user-auth.response.dto';
+import { UserProfileResponseDto } from './user-profile.response.dto';
 
-export class OAuthCallbackResponseDto {
+export class UserLoginResponseDto {
   @ApiProperty({
-    description: 'User profile information',
-    type: UserAuthResponseDto,
+    description: 'Regular user profile information',
+    type: UserProfileResponseDto,
   })
-  user: UserAuthResponseDto;
+  user: UserProfileResponseDto;
 
   @ApiProperty({ description: 'JWT access token (15 min TTL)' })
   accessToken: string;

--- a/src/modules/auth/guards/jwt-user-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-user-auth.guard.ts
@@ -8,7 +8,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { IS_PUBLIC_KEY } from '../../../common/decorators/public.decorator';
 
 @Injectable()
-export class JwtAdminAuthGuard extends AuthGuard('jwt-admin') {
+export class JwtUserAuthGuard extends AuthGuard('jwt-user') {
   constructor(private reflector: Reflector) {
     super();
   }

--- a/src/modules/auth/guards/jwt-user-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-user-auth.guard.ts
@@ -3,26 +3,11 @@ import {
   ExecutionContext,
   UnauthorizedException,
 } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
-import { IS_PUBLIC_KEY } from '../../../common/decorators/public.decorator';
 
 @Injectable()
 export class JwtUserAuthGuard extends AuthGuard('jwt-user') {
-  constructor(private reflector: Reflector) {
-    super();
-  }
-
   canActivate(context: ExecutionContext) {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
-
-    if (isPublic) {
-      return true;
-    }
-
     return super.canActivate(context);
   }
 

--- a/src/modules/auth/mappers/auth.mapper.ts
+++ b/src/modules/auth/mappers/auth.mapper.ts
@@ -5,6 +5,7 @@ import { AdminAuthResponseDto } from '../dto/response/admin-auth.response.dto';
 import { AdminLoginResponseDto } from '../dto/response/admin-login.response.dto';
 import { AdminSignupResponseDto } from '../dto/response/admin-signup.response.dto';
 import { UserAuthResponseDto } from '../dto/response/user-auth.response.dto';
+import { UserLoginResponseDto } from '../dto/response/user-login.response.dto';
 import { UserProfileResponseDto } from '../dto/response/user-profile.response.dto';
 import { User } from '../entities/user.entity';
 import { AuthCredentials } from '../entities/auth-credentials.entity';
@@ -157,6 +158,22 @@ export class AuthMapper {
 
     const response = new UserAuthResponseDto();
     response.user = this.userToProfileResponse(user);
+
+    return response;
+  }
+
+  userToUserLoginResponse(user: User, tokens: TokenPair): UserLoginResponseDto {
+    if (!user) {
+      throw new BadRequestException('User data is required');
+    }
+    if (!tokens) {
+      throw new BadRequestException('Tokens are required');
+    }
+
+    const response = new UserLoginResponseDto();
+    response.user = this.userToProfileResponse(user);
+    response.accessToken = tokens.accessToken;
+    response.refreshToken = tokens.refreshToken;
 
     return response;
   }

--- a/src/modules/auth/otp.controller.ts
+++ b/src/modules/auth/otp.controller.ts
@@ -10,7 +10,6 @@ import { Throttle } from '@nestjs/throttler';
 import { Public } from '../../common/decorators/public.decorator';
 import { OtpService } from './otp.service';
 import { AuthService } from './auth.service';
-import { TokenPair } from './entities/token-pair.entity';
 import { VerifyOtpRequestDto } from './dto/request/verify-otp.request.dto';
 import { ResendOtpRequestDto } from './dto/request/resend-otp.request.dto';
 import { VerifyResetOtpRequestDto } from './dto/request/verify-reset-otp.request';

--- a/src/modules/auth/otp.controller.ts
+++ b/src/modules/auth/otp.controller.ts
@@ -59,12 +59,14 @@ export class OtpController {
       verifyOtpRequestDto.otp,
     );
 
+    const audience = user.role === 'PLATFORM_ADMIN' ? 'platform-admin' : 'user';
+
     const tokenData = await this.authService.getTokens(
       user.id,
       user.email,
       user.role,
       user.isMasterAdmin,
-      'user',
+      audience,
     );
     await this.authService.updateRefreshToken(user.id, tokenData.refreshToken);
 

--- a/src/modules/auth/otp.controller.ts
+++ b/src/modules/auth/otp.controller.ts
@@ -1,11 +1,5 @@
 import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
-  ApiBody,
-  ApiSecurity,
-} from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { Public } from '../../common/decorators/public.decorator';
 import { OtpService } from './otp.service';
@@ -30,28 +24,23 @@ export class OtpController {
   @Public()
   @Post('verify-signup')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
-  @Throttle({ default: { limit: 5, ttl: 300000 } }) // 5 attempts per 5 minutes
+  @Throttle({ default: { limit: 5, ttl: 300000 } })
   @ApiOperation({
     summary: 'Verify email OTP for user signup',
     description:
-      'Verifies the OTP sent to user email address during registration process. Upon successful verification, the email is marked as verified and user account is activated. Rate limited to 5 attempts per 5 minutes to prevent brute force attacks.',
+      'Verifies the OTP sent to user email address during registration process. Upon successful verification, the email is marked as verified, user account is activated, and JWT tokens are issued.',
   })
   @ApiBody({ type: VerifyOtpRequestDto })
   @ApiResponse({
     status: 200,
     description:
-      'Email verified successfully. User account is now active and email is confirmed.',
+      'Email verified successfully. User account is now active and JWT tokens are returned.',
     type: OtpVerificationResponseDto,
   })
   @ApiResponse({
     status: 400,
     description:
       'Bad Request - Invalid OTP code, expired OTP, or email already verified',
-  })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
   })
   @ApiResponse({
     status: 404,
@@ -90,8 +79,7 @@ export class OtpController {
   @Public()
   @Post('resend-signup')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
-  @Throttle({ default: { limit: 5, ttl: 300000 } }) // 5 attempts per 5 minutes
+  @Throttle({ default: { limit: 5, ttl: 300000 } })
   @ApiOperation({
     summary: 'Resend signup email verification OTP',
     description:
@@ -107,10 +95,6 @@ export class OtpController {
   @ApiResponse({
     status: 400,
     description: 'Bad Request - Email already verified or invalid email format',
-  })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
   })
   @ApiResponse({
     status: 404,
@@ -135,8 +119,7 @@ export class OtpController {
   @Public()
   @Post('verify-reset')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
-  @Throttle({ default: { limit: 5, ttl: 300000 } }) // 5 attempts per 5 minutes
+  @Throttle({ default: { limit: 5, ttl: 300000 } })
   @ApiOperation({
     summary: 'Verify password reset OTP',
     description:
@@ -153,10 +136,6 @@ export class OtpController {
     status: 400,
     description:
       'Bad Request - Invalid OTP format, invalid OTP code, expired OTP, or maximum attempts exceeded',
-  })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
   })
   @ApiResponse({
     status: 429,

--- a/src/modules/auth/otp.controller.ts
+++ b/src/modules/auth/otp.controller.ts
@@ -4,11 +4,13 @@ import {
   ApiOperation,
   ApiResponse,
   ApiBody,
-  ApiBearerAuth,
+  ApiSecurity,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
+import { Public } from '../../common/decorators/public.decorator';
 import { OtpService } from './otp.service';
 import { AuthService } from './auth.service';
+import { TokenPair } from './entities/token-pair.entity';
 import { VerifyOtpRequestDto } from './dto/request/verify-otp.request.dto';
 import { ResendOtpRequestDto } from './dto/request/resend-otp.request.dto';
 import { VerifyResetOtpRequestDto } from './dto/request/verify-reset-otp.request';
@@ -18,7 +20,6 @@ import { VerifyResetOtpResponseDto } from './dto/response/verify-reset-otp.respo
 import { AuthMapper } from './mappers/auth.mapper';
 
 @ApiTags('OTP Verification')
-@ApiBearerAuth('JWT-auth')
 @Controller('otp')
 export class OtpController {
   constructor(
@@ -27,8 +28,10 @@ export class OtpController {
     private readonly authMapper: AuthMapper,
   ) {}
 
+  @Public()
   @Post('verify-signup')
   @HttpCode(HttpStatus.OK)
+  @ApiSecurity({})
   @Throttle({ default: { limit: 5, ttl: 300000 } }) // 5 attempts per 5 minutes
   @ApiOperation({
     summary: 'Verify email OTP for user signup',
@@ -68,14 +71,27 @@ export class OtpController {
       verifyOtpRequestDto.otp,
     );
 
+    const tokenData = await this.authService.getTokens(
+      user.id,
+      user.email,
+      user.role,
+      user.isMasterAdmin,
+      'user',
+    );
+    await this.authService.updateRefreshToken(user.id, tokenData.refreshToken);
+
     return {
       message: 'Email verified successfully',
       user: this.authMapper.userToProfileResponse(user),
+      accessToken: tokenData.accessToken,
+      refreshToken: tokenData.refreshToken,
     };
   }
 
+  @Public()
   @Post('resend-signup')
   @HttpCode(HttpStatus.OK)
+  @ApiSecurity({})
   @Throttle({ default: { limit: 5, ttl: 300000 } }) // 5 attempts per 5 minutes
   @ApiOperation({
     summary: 'Resend signup email verification OTP',
@@ -117,8 +133,10 @@ export class OtpController {
     };
   }
 
+  @Public()
   @Post('verify-reset')
   @HttpCode(HttpStatus.OK)
+  @ApiSecurity({})
   @Throttle({ default: { limit: 5, ttl: 300000 } }) // 5 attempts per 5 minutes
   @ApiOperation({
     summary: 'Verify password reset OTP',

--- a/src/modules/auth/strategies/jwt-user.strategy.ts
+++ b/src/modules/auth/strategies/jwt-user.strategy.ts
@@ -6,7 +6,7 @@ import { UsersService } from '../users.service';
 import { User, UserRole } from '../entities/user.entity';
 
 @Injectable()
-export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
+export class JwtUserStrategy extends PassportStrategy(Strategy, 'jwt-user') {
   constructor(
     private configService: ConfigService,
     private usersService: UsersService,
@@ -15,14 +15,14 @@ export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
       secretOrKey: configService.get<string>('JWT_SECRET'),
-      audience: 'platform-admin',
+      audience: 'user',
       issuer: configService.get<string>('app.name', 'PrismaCV'),
       algorithms: ['HS256'],
     });
   }
 
   async validate(payload: any): Promise<User> {
-    if (payload.role !== UserRole.PLATFORM_ADMIN) {
+    if (payload.role !== UserRole.REGULAR) {
       throw new UnauthorizedException('Insufficient permissions');
     }
 

--- a/src/modules/auth/strategies/jwt-user.strategy.ts
+++ b/src/modules/auth/strategies/jwt-user.strategy.ts
@@ -31,6 +31,10 @@ export class JwtUserStrategy extends PassportStrategy(Strategy, 'jwt-user') {
       throw new UnauthorizedException('User not found');
     }
 
+    if (user.role !== UserRole.REGULAR) {
+      throw new UnauthorizedException('Insufficient permissions');
+    }
+
     return user;
   }
 }

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -31,6 +31,10 @@ export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
       throw new UnauthorizedException('User not found');
     }
 
+    if (user.role !== UserRole.PLATFORM_ADMIN) {
+      throw new UnauthorizedException('Insufficient permissions');
+    }
+
     return user;
   }
 }

--- a/src/modules/auth/user-auth.controller.ts
+++ b/src/modules/auth/user-auth.controller.ts
@@ -14,7 +14,6 @@ import {
   ApiResponse,
   ApiBody,
   ApiBearerAuth,
-  ApiSecurity,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { Public } from '../../common/decorators/public.decorator';
@@ -32,7 +31,6 @@ import { UserAuthResponseDto } from './dto/response/user-auth.response.dto';
 import { ForgotPasswordResponseDto } from './dto/response/forgot-password.response.dto';
 import { ResetPasswordResponseDto } from './dto/response/rese-password.response.dto';
 import { ChangePasswordResponseDto } from './dto/response/change-password.response.dto';
-import { AdminAuthResponseDto } from './dto/response/admin-auth.response.dto';
 import { AuthMapper } from './mappers/auth.mapper';
 import { User } from './entities/user.entity';
 
@@ -47,7 +45,6 @@ export class UserAuthController {
   @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
   @ApiOperation({
     summary: 'Regular user authentication',
     description:
@@ -62,8 +59,7 @@ export class UserAuthController {
   })
   @ApiResponse({
     status: 401,
-    description:
-      'Unauthorized - Invalid credentials or email not verified',
+    description: 'Unauthorized - Invalid credentials or email not verified',
   })
   async login(
     @Body() loginRequestDto: UserLoginRequestDto,
@@ -77,7 +73,6 @@ export class UserAuthController {
   @Public()
   @Post('signup')
   @HttpCode(HttpStatus.CREATED)
-  @ApiSecurity({})
   @ApiOperation({
     summary: 'Regular user registration',
     description:
@@ -109,7 +104,6 @@ export class UserAuthController {
   @Public()
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
   @Throttle({ default: { limit: 5, ttl: 300000 } })
   @ApiOperation({
     summary: 'Request password reset for user',
@@ -141,7 +135,6 @@ export class UserAuthController {
   @Public()
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
   @ApiOperation({
     summary: 'Reset user password with token',
     description:
@@ -173,6 +166,7 @@ export class UserAuthController {
     );
   }
 
+  @Public()
   @UseGuards(JwtUserAuthGuard)
   @Post('change-password')
   @HttpCode(HttpStatus.OK)
@@ -214,7 +208,6 @@ export class UserAuthController {
   @Public()
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
-  @ApiSecurity({})
   @ApiOperation({
     summary: 'Refresh user access token',
     description:
@@ -225,7 +218,7 @@ export class UserAuthController {
     status: 200,
     description:
       'Token refreshed successfully. Response includes user profile and new JWT tokens.',
-    type: AdminAuthResponseDto,
+    type: UserLoginResponseDto,
   })
   @ApiResponse({
     status: 401,
@@ -237,7 +230,7 @@ export class UserAuthController {
   })
   async refresh(
     @Body() refreshTokenRequestDto: RefreshTokenRequestDto,
-  ): Promise<AdminAuthResponseDto> {
+  ): Promise<UserLoginResponseDto> {
     if (!refreshTokenRequestDto?.refreshToken) {
       throw new BadRequestException('Refresh token is required');
     }
@@ -245,8 +238,9 @@ export class UserAuthController {
     try {
       const result = await this.authService.refreshToken(
         refreshTokenRequestDto.refreshToken,
+        'user',
       );
-      return this.authMapper.userToAdminAuthResponse(
+      return this.authMapper.userToUserLoginResponse(
         result.user,
         result.tokens!,
       );

--- a/src/modules/auth/user-auth.controller.ts
+++ b/src/modules/auth/user-auth.controller.ts
@@ -242,7 +242,7 @@ export class UserAuthController {
       );
       return this.authMapper.userToUserLoginResponse(
         result.user,
-        result.tokens!,
+        result.tokens,
       );
     } catch (error) {
       if (error instanceof UnauthorizedException) {

--- a/src/modules/auth/user-auth.controller.ts
+++ b/src/modules/auth/user-auth.controller.ts
@@ -1,26 +1,42 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  UnauthorizedException,
+  BadRequestException,
+} from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
   ApiResponse,
   ApiBody,
   ApiBearerAuth,
+  ApiSecurity,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
+import { Public } from '../../common/decorators/public.decorator';
+import { GetUser } from '../../common/decorators/get-user.decorator';
+import { JwtUserAuthGuard } from './guards/jwt-user-auth.guard';
 import { AuthService } from './auth.service';
 import { UserLoginRequestDto } from './dto/request/user-login.request.dto';
 import { UserSignupRequestDto } from './dto/request/user-signup.request.dto';
 import { ForgotPasswordRequestDto } from './dto/request/forgot-password.request.dto';
 import { ResetPasswordRequestDto } from './dto/request/reset-password.request.dto';
 import { ChangePasswordRequestDto } from './dto/request/change-password.request.dto';
+import { RefreshTokenRequestDto } from './dto/request/refresh-token.request.dto';
+import { UserLoginResponseDto } from './dto/response/user-login.response.dto';
 import { UserAuthResponseDto } from './dto/response/user-auth.response.dto';
 import { ForgotPasswordResponseDto } from './dto/response/forgot-password.response.dto';
 import { ResetPasswordResponseDto } from './dto/response/rese-password.response.dto';
 import { ChangePasswordResponseDto } from './dto/response/change-password.response.dto';
+import { AdminAuthResponseDto } from './dto/response/admin-auth.response.dto';
 import { AuthMapper } from './mappers/auth.mapper';
+import { User } from './entities/user.entity';
 
 @ApiTags('User Authentication')
-@ApiBearerAuth('JWT-auth')
 @Controller('auth/user')
 export class UserAuthController {
   constructor(
@@ -28,56 +44,55 @@ export class UserAuthController {
     private readonly authMapper: AuthMapper,
   ) {}
 
+  @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @ApiSecurity({})
   @ApiOperation({
     summary: 'Regular user authentication',
-    description: 'Authenticates a regular user and returns profile data.',
+    description:
+      'Authenticates a regular user and returns JWT tokens with profile data.',
   })
   @ApiBody({ type: UserLoginRequestDto })
   @ApiResponse({
     status: 200,
-    description: 'User login successful. Response includes user profile data.',
-    type: UserAuthResponseDto,
+    description:
+      'User login successful. Response includes JWT tokens and user profile data.',
+    type: UserLoginResponseDto,
   })
   @ApiResponse({
     status: 401,
-    description: 'Unauthorized - Invalid credentials',
-  })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
+    description:
+      'Unauthorized - Invalid credentials or email not verified',
   })
   async login(
     @Body() loginRequestDto: UserLoginRequestDto,
-  ): Promise<UserAuthResponseDto> {
+  ): Promise<UserLoginResponseDto> {
     const credentials =
       this.authMapper.loginRequestToCredentials(loginRequestDto);
     const result = await this.authService.userLogin(credentials);
-    return this.authMapper.userToUserAuthResponse(result.user);
+    return this.authMapper.userToUserLoginResponse(result.user, result.tokens);
   }
 
+  @Public()
   @Post('signup')
   @HttpCode(HttpStatus.CREATED)
+  @ApiSecurity({})
   @ApiOperation({
     summary: 'Regular user registration',
     description:
-      'Registers a new regular user with REGULAR role. New users receive profile data only.',
+      'Registers a new regular user with REGULAR role. New users receive profile data only and must verify email before logging in.',
   })
   @ApiBody({ type: UserSignupRequestDto })
   @ApiResponse({
     status: 201,
     description:
-      'User registered successfully. Response includes user profile data.',
+      'User registered successfully. Response includes user profile data. Verify email via OTP before logging in.',
     type: UserAuthResponseDto,
   })
   @ApiResponse({
     status: 400,
     description: 'Bad Request - Validation errors',
-  })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
   })
   @ApiResponse({
     status: 409,
@@ -91,9 +106,11 @@ export class UserAuthController {
     return this.authMapper.userToUserAuthResponse(result.user);
   }
 
+  @Public()
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
-  @Throttle({ default: { limit: 5, ttl: 300000 } }) // 5 attempts per 5 minutes (300 seconds = 300000ms)
+  @ApiSecurity({})
+  @Throttle({ default: { limit: 5, ttl: 300000 } })
   @ApiOperation({
     summary: 'Request password reset for user',
     description:
@@ -111,10 +128,6 @@ export class UserAuthController {
     description: 'Bad Request - Invalid email format or validation errors',
   })
   @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
-  })
-  @ApiResponse({
     status: 429,
     description:
       'Too Many Requests - Rate limit exceeded (5 attempts per 5 minutes)',
@@ -125,8 +138,10 @@ export class UserAuthController {
     return await this.authService.forgotPassword(forgotPasswordDto.email);
   }
 
+  @Public()
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
+  @ApiSecurity({})
   @ApiOperation({
     summary: 'Reset user password with token',
     description:
@@ -148,10 +163,6 @@ export class UserAuthController {
     status: 401,
     description: 'Unauthorized - Invalid or expired reset token',
   })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
-  })
   async resetPassword(
     @Body() resetPasswordDto: ResetPasswordRequestDto,
   ): Promise<ResetPasswordResponseDto> {
@@ -162,12 +173,14 @@ export class UserAuthController {
     );
   }
 
+  @UseGuards(JwtUserAuthGuard)
   @Post('change-password')
   @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth('JWT-auth')
   @ApiOperation({
-    summary: 'Change password for specified user',
+    summary: 'Change password for authenticated user',
     description:
-      'Changes password for the user identified by userId in request body. Requires current password verification and enforces password policy (minimum 8 characters). All user sessions will be invalidated after successful password change for security.',
+      'Changes password for the currently authenticated user. Requires current password verification and enforces password policy (minimum 8 characters). All user sessions will be invalidated after successful password change for security.',
   })
   @ApiBody({ type: ChangePasswordRequestDto })
   @ApiResponse({
@@ -184,20 +197,64 @@ export class UserAuthController {
   @ApiResponse({
     status: 401,
     description:
-      'Unauthorized - Current password is incorrect or user not found',
-  })
-  @ApiResponse({
-    status: 403,
-    description: 'Forbidden - Missing or invalid JWT token',
+      'Unauthorized - Current password is incorrect or missing JWT token',
   })
   async changePassword(
     @Body() changePasswordDto: ChangePasswordRequestDto,
+    @GetUser() user: User,
   ): Promise<ChangePasswordResponseDto> {
     return await this.authService.changePassword(
-      changePasswordDto.userId,
+      user.id,
       changePasswordDto.currentPassword,
       changePasswordDto.newPassword,
       changePasswordDto.confirmPassword,
     );
+  }
+
+  @Public()
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @ApiSecurity({})
+  @ApiOperation({
+    summary: 'Refresh user access token',
+    description:
+      'Refreshes JWT access token using a valid refresh token. Only available for REGULAR users.',
+  })
+  @ApiBody({ type: RefreshTokenRequestDto })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Token refreshed successfully. Response includes user profile and new JWT tokens.',
+    type: AdminAuthResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or expired refresh token',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad Request - Refresh token is required',
+  })
+  async refresh(
+    @Body() refreshTokenRequestDto: RefreshTokenRequestDto,
+  ): Promise<AdminAuthResponseDto> {
+    if (!refreshTokenRequestDto?.refreshToken) {
+      throw new BadRequestException('Refresh token is required');
+    }
+
+    try {
+      const result = await this.authService.refreshToken(
+        refreshTokenRequestDto.refreshToken,
+      );
+      return this.authMapper.userToAdminAuthResponse(
+        result.user,
+        result.tokens!,
+      );
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw new UnauthorizedException('Invalid or expired refresh token');
+      }
+      throw error;
+    }
   }
 }

--- a/src/modules/oauth/oauth.controller.ts
+++ b/src/modules/oauth/oauth.controller.ts
@@ -25,6 +25,7 @@ import { LinkedinImportRequestDto } from './dto/linkedin-import.request.dto';
 import { LinkedinCvResponseDto } from './dto/linkedin-cv.response.dto';
 import { AuthMapper } from '@/modules/auth/mappers/auth.mapper';
 import { User } from '@/modules/auth/entities/user.entity';
+import { TokenPair } from '@/modules/auth/entities/token-pair.entity';
 import { LinkedInCvService } from './services/linkedin-cv.service';
 
 @ApiTags('OAuth Authentication')
@@ -64,12 +65,12 @@ export class OAuthController {
   @UseGuards(LinkedInAuthGuard)
   @ApiExcludeEndpoint() // Keep hidden from Swagger
   async linkedinCallback(@Req() req: Request, @Res() res: Response) {
-    const { user } = req.user as { user: User };
-
-    const userResponse = this.authMapper.userToUserAuthResponse(user);
+    const { user, tokens } = req.user as { user: User; tokens: TokenPair };
 
     const response: OAuthCallbackResponseDto = {
-      user: userResponse,
+      user: this.authMapper.userToUserAuthResponse(user),
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
     };
 
     return res.status(HttpStatus.OK).json(response);
@@ -99,12 +100,12 @@ export class OAuthController {
   @UseGuards(GoogleAuthGuard)
   @ApiExcludeEndpoint() // Keep hidden from Swagger
   async googleCallback(@Req() req: Request, @Res() res: Response) {
-    const { user } = req.user as { user: User };
-
-    const userResponse = this.authMapper.userToUserAuthResponse(user);
+    const { user, tokens } = req.user as { user: User; tokens: TokenPair };
 
     const response: OAuthCallbackResponseDto = {
-      user: userResponse,
+      user: this.authMapper.userToUserAuthResponse(user),
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
     };
 
     return res.status(HttpStatus.OK).json(response);

--- a/src/modules/oauth/oauth.controller.ts
+++ b/src/modules/oauth/oauth.controller.ts
@@ -138,12 +138,12 @@ export class OAuthController {
     @Req() req: Request,
     @Body() body: LinkedinImportRequestDto,
   ): Promise<LinkedinCvResponseDto> {
-    const authUser = (
-      req.user as { id?: string; userId?: string; sub?: string } | undefined
-    )?.id
-      ?? (req.user as { id?: string; userId?: string; sub?: string } | undefined)
-        ?.userId
-      ?? (req.user as { id?: string; userId?: string; sub?: string } | undefined)
+    const authUser =
+      (req.user as { id?: string; userId?: string; sub?: string } | undefined)
+        ?.id ??
+      (req.user as { id?: string; userId?: string; sub?: string } | undefined)
+        ?.userId ??
+      (req.user as { id?: string; userId?: string; sub?: string } | undefined)
         ?.sub;
     if (!authUser) {
       throw new BadRequestException('Authenticated user is required');

--- a/src/modules/oauth/oauth.module.ts
+++ b/src/modules/oauth/oauth.module.ts
@@ -8,7 +8,6 @@ import { LinkedInStrategy } from './strategies/linkedin.strategy';
 import { GoogleOAuthProvider } from './services/google-oauth.provider';
 import { GoogleStrategy } from './strategies/google.strategy';
 import { AuthModule } from '@/modules/auth/auth.module';
-import { PrismaService } from '@/config/prisma.service';
 import { AuthMapper } from '@/modules/auth/mappers/auth.mapper';
 
 @Module({
@@ -21,7 +20,6 @@ import { AuthMapper } from '@/modules/auth/mappers/auth.mapper';
     LinkedInStrategy,
     GoogleOAuthProvider,
     GoogleStrategy,
-    PrismaService,
     AuthMapper,
   ],
   exports: [OAuthService],

--- a/src/modules/oauth/oauth.module.ts
+++ b/src/modules/oauth/oauth.module.ts
@@ -7,12 +7,12 @@ import { LinkedInCvService } from './services/linkedin-cv.service';
 import { LinkedInStrategy } from './strategies/linkedin.strategy';
 import { GoogleOAuthProvider } from './services/google-oauth.provider';
 import { GoogleStrategy } from './strategies/google.strategy';
-import { UsersService } from '@/modules/auth/users.service';
+import { AuthModule } from '@/modules/auth/auth.module';
 import { PrismaService } from '@/config/prisma.service';
 import { AuthMapper } from '@/modules/auth/mappers/auth.mapper';
 
 @Module({
-  imports: [PassportModule],
+  imports: [PassportModule, AuthModule],
   controllers: [OAuthController],
   providers: [
     OAuthService,
@@ -21,7 +21,6 @@ import { AuthMapper } from '@/modules/auth/mappers/auth.mapper';
     LinkedInStrategy,
     GoogleOAuthProvider,
     GoogleStrategy,
-    UsersService,
     PrismaService,
     AuthMapper,
   ],

--- a/src/modules/oauth/services/oauth.service.ts
+++ b/src/modules/oauth/services/oauth.service.ts
@@ -1,7 +1,12 @@
-import { Injectable, Logger, ConflictException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  ConflictException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { UsersService } from '@/modules/auth/users.service';
 import { AuthService } from '@/modules/auth/auth.service';
-import { User } from '@/modules/auth/entities/user.entity';
+import { User, UserRole } from '@/modules/auth/entities/user.entity';
 import { TokenPair } from '@/modules/auth/entities/token-pair.entity';
 import { OAuthUserData } from '../interfaces/oauth-user.interface';
 
@@ -58,6 +63,12 @@ export class OAuthService {
     }
 
     user = await this.usersService.updateOAuthMetadata(user.id, oauthMetadata);
+
+    if (user.role !== UserRole.REGULAR) {
+      throw new UnauthorizedException(
+        'OAuth authentication is only available for regular users',
+      );
+    }
 
     const tokenData = await this.authService.getTokens(
       user.id,

--- a/src/modules/oauth/services/oauth.service.ts
+++ b/src/modules/oauth/services/oauth.service.ts
@@ -39,6 +39,12 @@ export class OAuthService {
       const existingUser = await this.usersService.findByEmail(profile.email);
 
       if (existingUser) {
+        if (existingUser.role !== UserRole.REGULAR) {
+          throw new UnauthorizedException(
+            'OAuth authentication is only available for regular users',
+          );
+        }
+
         if (existingUser.provider) {
           throw new ConflictException(
             `An account with this email already exists using ${existingUser.provider} authentication`,
@@ -62,13 +68,13 @@ export class OAuthService {
       }
     }
 
-    user = await this.usersService.updateOAuthMetadata(user.id, oauthMetadata);
-
     if (user.role !== UserRole.REGULAR) {
       throw new UnauthorizedException(
         'OAuth authentication is only available for regular users',
       );
     }
+
+    user = await this.usersService.updateOAuthMetadata(user.id, oauthMetadata);
 
     const tokenData = await this.authService.getTokens(
       user.id,

--- a/src/modules/oauth/services/oauth.service.ts
+++ b/src/modules/oauth/services/oauth.service.ts
@@ -1,20 +1,22 @@
 import { Injectable, Logger, ConflictException } from '@nestjs/common';
 import { UsersService } from '@/modules/auth/users.service';
+import { AuthService } from '@/modules/auth/auth.service';
 import { User } from '@/modules/auth/entities/user.entity';
+import { TokenPair } from '@/modules/auth/entities/token-pair.entity';
 import { OAuthUserData } from '../interfaces/oauth-user.interface';
 
 @Injectable()
 export class OAuthService {
   private readonly logger = new Logger(OAuthService.name);
 
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+  ) {}
 
-  /**
-   * Authenticate or register a user via OAuth
-   * Returns user profile only (no JWT tokens)
-   * OAuth users are REGULAR users and don't receive JWT tokens
-   */
-  async authenticate(oauthData: OAuthUserData): Promise<{ user: User }> {
+  async authenticate(
+    oauthData: OAuthUserData,
+  ): Promise<{ user: User; tokens: TokenPair }> {
     const { profile, accessToken, refreshToken, expiresAt } = oauthData;
     const oauthMetadata = {
       avatarUrl: profile.picture,
@@ -23,20 +25,16 @@ export class OAuthService {
       oauthTokenExpiresAt: expiresAt,
     };
 
-    // Try to find existing user by provider + providerId
     let user = await this.usersService.findByProvider(
       profile.provider,
       profile.providerId,
     );
 
     if (!user) {
-      // Try to find by email (account linking scenario)
       const existingUser = await this.usersService.findByEmail(profile.email);
 
       if (existingUser) {
-        // If user exists but doesn't have OAuth, link the account
         if (existingUser.provider) {
-          // User exists with different provider - conflict
           throw new ConflictException(
             `An account with this email already exists using ${existingUser.provider} authentication`,
           );
@@ -52,7 +50,6 @@ export class OAuthService {
           );
         }
       } else {
-        // Create new OAuth user
         this.logger.log(
           `Creating new OAuth user: email=${profile.email}, provider=${profile.provider}`,
         );
@@ -62,10 +59,23 @@ export class OAuthService {
 
     user = await this.usersService.updateOAuthMetadata(user.id, oauthMetadata);
 
+    const tokenData = await this.authService.getTokens(
+      user.id,
+      user.email,
+      user.role,
+      user.isMasterAdmin,
+      'user',
+    );
+    await this.authService.updateRefreshToken(user.id, tokenData.refreshToken);
+
+    const tokens = new TokenPair();
+    tokens.accessToken = tokenData.accessToken;
+    tokens.refreshToken = tokenData.refreshToken;
+
     this.logger.log(
       `OAuth authentication successful: email=${user.email}, userId=${user.id}, provider=${profile.provider}`,
     );
 
-    return { user };
+    return { user, tokens };
   }
 }

--- a/src/modules/oauth/strategies/google.strategy.ts
+++ b/src/modules/oauth/strategies/google.strategy.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { OAuthService } from '../services/oauth.service';
 import { GoogleOAuthProvider } from '../services/google-oauth.provider';
 import { User } from '@/modules/auth/entities/user.entity';
+import { TokenPair } from '@/modules/auth/entities/token-pair.entity';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
@@ -25,7 +26,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     accessToken: string,
     refreshToken: string,
     profile: Profile,
-  ): Promise<{ user: User }> {
+  ): Promise<{ user: User; tokens: TokenPair }> {
     // Transform Google profile → our internal format
     const oauthProfile = this.googleProvider.validateProfile(profile);
 

--- a/src/modules/oauth/strategies/linkedin.strategy.ts
+++ b/src/modules/oauth/strategies/linkedin.strategy.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { OAuthService } from '../services/oauth.service';
 import { LinkedInOAuthProvider } from '../services/linkedin-oauth.provider';
 import { User } from '@/modules/auth/entities/user.entity';
+import { TokenPair } from '@/modules/auth/entities/token-pair.entity';
 
 @Injectable()
 export class LinkedInStrategy extends PassportStrategy(Strategy, 'linkedin') {
@@ -25,7 +26,7 @@ export class LinkedInStrategy extends PassportStrategy(Strategy, 'linkedin') {
     accessToken: string,
     refreshToken: string,
     profile: Profile,
-  ): Promise<{ user: User }> {
+  ): Promise<{ user: User; tokens: TokenPair }> {
     // Transform LinkedIn profile to our OAuthProfile format
     const oauthProfile = this.linkedinProvider.validateProfile(profile);
 

--- a/src/shared/constants/jwt.constants.ts
+++ b/src/shared/constants/jwt.constants.ts
@@ -1,29 +1,4 @@
-/**
- * JWT Token Expiration Constants
- * Centralized constants for JWT token expiration times
- */
 export const JWT_EXPIRATION = {
-  /**
-   * Access token expiration time
-   * Default: 15 minutes
-   */
   ACCESS_TOKEN: '15m',
-
-  /**
-   * Refresh token expiration time
-   * Default: 7 days
-   */
   REFRESH_TOKEN: '7d',
-
-  /**
-   * Default JWT expiration time (used in config)
-   * Default: 7 days
-   */
-  DEFAULT_EXPIRES_IN: '7d',
-
-  /**
-   * Default JWT refresh expiration time (used in config)
-   * Default: 30 days
-   */
-  DEFAULT_REFRESH_EXPIRES_IN: '30d',
 } as const;

--- a/src/shared/constants/jwt.constants.ts
+++ b/src/shared/constants/jwt.constants.ts
@@ -2,3 +2,5 @@ export const JWT_EXPIRATION = {
   ACCESS_TOKEN: '15m',
   REFRESH_TOKEN: '7d',
 } as const;
+
+export const JWT_MIN_SECRET_LENGTH = 32;

--- a/src/shared/mappers/base.mapper.ts
+++ b/src/shared/mappers/base.mapper.ts
@@ -11,9 +11,10 @@ export interface IMapper<TDto, TEntity> {
 /**
  * Abstract base mapper class providing common functionality
  */
-export abstract class BaseMapper<TDto, TEntity>
-  implements IMapper<TDto, TEntity>
-{
+export abstract class BaseMapper<TDto, TEntity> implements IMapper<
+  TDto,
+  TEntity
+> {
   /**
    * Convert DTO to Entity - must be implemented by concrete mappers
    */

--- a/test/e2e/auth-refresh.e2e-spec.ts
+++ b/test/e2e/auth-refresh.e2e-spec.ts
@@ -32,10 +32,10 @@ describe('Auth Refresh (e2e)', () => {
     await app.close();
   });
 
-  describe('/auth/refresh (POST)', () => {
+  describe('/auth/admin/refresh (POST)', () => {
     it('should refresh tokens successfully with valid refresh token', () => {
       return request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/auth/admin/refresh')
         .send({ refreshToken })
         .expect(200)
         .expect(res => {
@@ -50,14 +50,14 @@ describe('Auth Refresh (e2e)', () => {
 
     it('should return 401 for invalid refresh token', () => {
       return request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/auth/admin/refresh')
         .send({ refreshToken: 'invalidtoken' })
         .expect(401);
     });
 
     it('should return 400 for missing refresh token', () => {
       return request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/auth/admin/refresh')
         .send({})
         .expect(400); // Should now return 400 with our validation fix
     });
@@ -67,7 +67,7 @@ describe('Auth Refresh (e2e)', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE1MTYyMzkwMjJ9.invalid';
 
       return request(app.getHttpServer())
-        .post('/auth/refresh')
+        .post('/auth/admin/refresh')
         .send({ refreshToken: expiredToken })
         .expect(401);
     });

--- a/test/modules/auth/auth.controller.spec.ts
+++ b/test/modules/auth/auth.controller.spec.ts
@@ -223,6 +223,7 @@ describe('AuthController', () => {
 
       expect(authService.refreshToken).toHaveBeenCalledWith(
         refreshDto.refreshToken,
+        'platform-admin',
       );
       expect(authMapper.userToAdminAuthResponse).toHaveBeenCalledWith(
         mockAdminUser,
@@ -245,6 +246,7 @@ describe('AuthController', () => {
       );
       expect(authService.refreshToken).toHaveBeenCalledWith(
         refreshDto.refreshToken,
+        'platform-admin',
       );
       expect(authMapper.userToAdminAuthResponse).not.toHaveBeenCalled();
     });
@@ -267,6 +269,7 @@ describe('AuthController', () => {
       );
       expect(authService.refreshToken).toHaveBeenCalledWith(
         refreshDto.refreshToken,
+        'platform-admin',
       );
       expect(authMapper.userToAdminAuthResponse).toHaveBeenCalledWith(
         mockAdminUser,

--- a/test/modules/auth/auth.mapper.spec.ts
+++ b/test/modules/auth/auth.mapper.spec.ts
@@ -57,9 +57,9 @@ describe('AuthMapper', () => {
     it('should throw BadRequestException when tokens are null', () => {
       const user = createTestUser();
 
-      expect(() =>
-        mapper.userToUserLoginResponse(user, null as any),
-      ).toThrow(BadRequestException);
+      expect(() => mapper.userToUserLoginResponse(user, null as any)).toThrow(
+        BadRequestException,
+      );
     });
   });
 
@@ -103,7 +103,11 @@ describe('AuthMapper', () => {
 
   describe('signupRequestToEntity', () => {
     it('should map signup DTO to User entity', () => {
-      const dto = { email: 'User@Example.COM', password: 'pass123', name: ' Test ' };
+      const dto = {
+        email: 'User@Example.COM',
+        password: 'pass123',
+        name: ' Test ',
+      };
 
       const result = mapper.signupRequestToEntity(dto);
 
@@ -120,7 +124,11 @@ describe('AuthMapper', () => {
 
     it('should throw BadRequestException when email is missing', () => {
       expect(() =>
-        mapper.signupRequestToEntity({ email: '', password: 'pass', name: 'x' }),
+        mapper.signupRequestToEntity({
+          email: '',
+          password: 'pass',
+          name: 'x',
+        }),
       ).toThrow(BadRequestException);
     });
   });

--- a/test/modules/auth/auth.mapper.spec.ts
+++ b/test/modules/auth/auth.mapper.spec.ts
@@ -1,0 +1,144 @@
+import { BadRequestException } from '@nestjs/common';
+import { AuthMapper } from '../../../src/modules/auth/mappers/auth.mapper';
+import { User, UserRole } from '../../../src/modules/auth/entities/user.entity';
+import { TokenPair } from '../../../src/modules/auth/entities/token-pair.entity';
+
+describe('AuthMapper', () => {
+  let mapper: AuthMapper;
+
+  const createTestUser = (): User => {
+    const user = new User();
+    user.id = '1';
+    user.email = 'user@example.com';
+    user.password = 'hashedpassword';
+    user.name = 'Test User';
+    user.role = UserRole.REGULAR;
+    user.emailVerified = true;
+    user.isMasterAdmin = false;
+    user.createdAt = new Date();
+    user.updatedAt = new Date();
+    return user;
+  };
+
+  const createTestTokens = (): TokenPair => {
+    const tokens = new TokenPair();
+    tokens.accessToken = 'access-token';
+    tokens.refreshToken = 'refresh-token';
+    return tokens;
+  };
+
+  beforeEach(() => {
+    mapper = new AuthMapper();
+  });
+
+  describe('userToUserLoginResponse', () => {
+    it('should map user and tokens to UserLoginResponseDto', () => {
+      const user = createTestUser();
+      const tokens = createTestTokens();
+
+      const result = mapper.userToUserLoginResponse(user, tokens);
+
+      expect(result.user.id).toBe('1');
+      expect(result.user.email).toBe('user@example.com');
+      expect(result.user.name).toBe('Test User');
+      expect(result.user.role).toBe(UserRole.REGULAR);
+      expect(result.accessToken).toBe('access-token');
+      expect(result.refreshToken).toBe('refresh-token');
+    });
+
+    it('should throw BadRequestException when user is null', () => {
+      const tokens = createTestTokens();
+
+      expect(() => mapper.userToUserLoginResponse(null as any, tokens)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when tokens are null', () => {
+      const user = createTestUser();
+
+      expect(() =>
+        mapper.userToUserLoginResponse(user, null as any),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe('userToProfileResponse', () => {
+    it('should map user to UserProfileResponseDto', () => {
+      const user = createTestUser();
+
+      const result = mapper.userToProfileResponse(user);
+
+      expect(result.id).toBe('1');
+      expect(result.email).toBe('user@example.com');
+      expect(result.name).toBe('Test User');
+      expect(result.role).toBe(UserRole.REGULAR);
+      expect(result.emailVerified).toBe(true);
+    });
+
+    it('should throw BadRequestException when user is null', () => {
+      expect(() => mapper.userToProfileResponse(null as any)).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('userToUserAuthResponse', () => {
+    it('should map user to UserAuthResponseDto (no tokens)', () => {
+      const user = createTestUser();
+
+      const result = mapper.userToUserAuthResponse(user);
+
+      expect(result.user.id).toBe('1');
+      expect(result.user.email).toBe('user@example.com');
+      expect(result).not.toHaveProperty('accessToken');
+    });
+
+    it('should throw BadRequestException when user is null', () => {
+      expect(() => mapper.userToUserAuthResponse(null as any)).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('signupRequestToEntity', () => {
+    it('should map signup DTO to User entity', () => {
+      const dto = { email: 'User@Example.COM', password: 'pass123', name: ' Test ' };
+
+      const result = mapper.signupRequestToEntity(dto);
+
+      expect(result.email).toBe('user@example.com');
+      expect(result.password).toBe('pass123');
+      expect(result.name).toBe('Test');
+    });
+
+    it('should throw BadRequestException when dto is null', () => {
+      expect(() => mapper.signupRequestToEntity(null as any)).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when email is missing', () => {
+      expect(() =>
+        mapper.signupRequestToEntity({ email: '', password: 'pass', name: 'x' }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe('loginRequestToCredentials', () => {
+    it('should map login DTO to AuthCredentials', () => {
+      const dto = { email: 'User@Example.COM', password: 'pass123' };
+
+      const result = mapper.loginRequestToCredentials(dto);
+
+      expect(result.email).toBe('user@example.com');
+      expect(result.password).toBe('pass123');
+    });
+
+    it('should throw BadRequestException when dto is null', () => {
+      expect(() => mapper.loginRequestToCredentials(null as any)).toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/test/modules/auth/auth.service.spec.ts
+++ b/test/modules/auth/auth.service.spec.ts
@@ -224,7 +224,8 @@ describe('AuthService', () => {
       const mockConfig = {
         get: jest.fn((key: string) => {
           if (key === 'JWT_SECRET') return undefined;
-          if (key === 'JWT_REFRESH_SECRET') return '01234567890123456789012345678901';
+          if (key === 'JWT_REFRESH_SECRET')
+            return '01234567890123456789012345678901';
           return undefined;
         }),
       } as unknown as ConfigService;
@@ -247,7 +248,8 @@ describe('AuthService', () => {
       const mockConfig = {
         get: jest.fn((key: string) => {
           if (key === 'JWT_SECRET') return 'short';
-          if (key === 'JWT_REFRESH_SECRET') return '01234567890123456789012345678901';
+          if (key === 'JWT_REFRESH_SECRET')
+            return '01234567890123456789012345678901';
           return undefined;
         }),
       } as unknown as ConfigService;
@@ -311,7 +313,9 @@ describe('AuthService', () => {
         accessToken: 'access',
         refreshToken: 'refresh',
       });
-      jest.spyOn(authService, 'updateRefreshToken').mockResolvedValue(undefined);
+      jest
+        .spyOn(authService, 'updateRefreshToken')
+        .mockResolvedValue(undefined);
 
       const result = await authService.userLogin(credentials);
 

--- a/test/modules/auth/auth.service.spec.ts
+++ b/test/modules/auth/auth.service.spec.ts
@@ -170,6 +170,7 @@ describe('AuthService', () => {
       user.email = 'test@example.com';
       user.password = 'hashedpassword';
       user.name = null;
+      user.role = UserRole.PLATFORM_ADMIN;
       user.refreshToken = 'hashed-token';
       user.createdAt = new Date();
       user.updatedAt = new Date();
@@ -182,12 +183,30 @@ describe('AuthService', () => {
       ).rejects.toThrow(UnauthorizedException);
     });
 
+    it('should throw UnauthorizedException if role does not match audience', async () => {
+      const user = new User();
+      user.id = '1';
+      user.email = 'test@example.com';
+      user.password = 'hashedpassword';
+      user.role = UserRole.REGULAR;
+      user.refreshToken = 'hashed-token';
+      user.createdAt = new Date();
+      user.updatedAt = new Date();
+
+      jest.spyOn(usersService, 'findById').mockResolvedValue(user);
+
+      await expect(
+        authService.refreshToken('some-refresh-token', 'platform-admin'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
     it('should return user entity and new tokens if refresh is successful', async () => {
       const user = new User();
       user.id = '1';
       user.email = 'test@example.com';
       user.password = 'hashedpassword';
       user.name = null;
+      user.role = UserRole.PLATFORM_ADMIN;
       user.refreshToken = 'hashed-token';
       user.createdAt = new Date();
       user.updatedAt = new Date();

--- a/test/modules/auth/auth.service.spec.ts
+++ b/test/modules/auth/auth.service.spec.ts
@@ -9,7 +9,7 @@ import * as bcrypt from 'bcryptjs';
 import { PrismaService } from '../../../src/config/prisma.service';
 import { EmailService } from '../../../src/modules/email/email.service';
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { User } from '../../../src/modules/auth/entities/user.entity';
+import { User, UserRole } from '../../../src/modules/auth/entities/user.entity';
 import { AuthCredentials } from '../../../src/modules/auth/entities/auth-credentials.entity';
 import { TokenPair } from '../../../src/modules/auth/entities/token-pair.entity';
 
@@ -37,6 +37,9 @@ describe('AuthService', () => {
                 OTP_EXPIRY_MINUTES: 10,
                 APP_NAME: 'PrismaCV',
                 'security.encryptionKey': '01234567890123456789012345678901',
+                JWT_SECRET: '01234567890123456789012345678901',
+                JWT_REFRESH_SECRET: '01234567890123456789012345678901',
+                'app.name': 'PrismaCV',
               };
               return config[key] ?? defaultValue;
             }),
@@ -209,6 +212,188 @@ describe('AuthService', () => {
       expect(result.tokens).toBeInstanceOf(TokenPair);
       expect(result.tokens.accessToken).toBe('new-access');
       expect(result.tokens.refreshToken).toBe('new-refresh');
+    });
+  });
+
+  describe('onModuleInit', () => {
+    it('should not throw when secrets are valid', () => {
+      expect(() => authService.onModuleInit()).not.toThrow();
+    });
+
+    it('should throw when JWT_SECRET is missing', () => {
+      const mockConfig = {
+        get: jest.fn((key: string) => {
+          if (key === 'JWT_SECRET') return undefined;
+          if (key === 'JWT_REFRESH_SECRET') return '01234567890123456789012345678901';
+          return undefined;
+        }),
+      } as unknown as ConfigService;
+
+      const service = new AuthService(
+        {} as any,
+        {} as any,
+        mockConfig,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+
+      expect(() => service.onModuleInit()).toThrow(
+        'JWT_SECRET is not set or too short',
+      );
+    });
+
+    it('should throw when JWT_SECRET is too short', () => {
+      const mockConfig = {
+        get: jest.fn((key: string) => {
+          if (key === 'JWT_SECRET') return 'short';
+          if (key === 'JWT_REFRESH_SECRET') return '01234567890123456789012345678901';
+          return undefined;
+        }),
+      } as unknown as ConfigService;
+
+      const service = new AuthService(
+        {} as any,
+        {} as any,
+        mockConfig,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+
+      expect(() => service.onModuleInit()).toThrow(
+        'JWT_SECRET is not set or too short',
+      );
+    });
+
+    it('should throw when JWT_REFRESH_SECRET is missing', () => {
+      const mockConfig = {
+        get: jest.fn((key: string) => {
+          if (key === 'JWT_SECRET') return '01234567890123456789012345678901';
+          if (key === 'JWT_REFRESH_SECRET') return undefined;
+          return undefined;
+        }),
+      } as unknown as ConfigService;
+
+      const service = new AuthService(
+        {} as any,
+        {} as any,
+        mockConfig,
+        {} as any,
+        {} as any,
+        {} as any,
+      );
+
+      expect(() => service.onModuleInit()).toThrow(
+        'JWT_REFRESH_SECRET is not set or too short',
+      );
+    });
+  });
+
+  describe('userLogin', () => {
+    it('should return user and tokens for valid REGULAR user with verified email', async () => {
+      const credentials = new AuthCredentials();
+      credentials.email = 'user@example.com';
+      credentials.password = 'password';
+
+      const user = new User();
+      user.id = '1';
+      user.email = 'user@example.com';
+      user.password = 'hashedpassword';
+      user.role = UserRole.REGULAR;
+      user.emailVerified = true;
+      user.isMasterAdmin = false;
+      user.createdAt = new Date();
+      user.updatedAt = new Date();
+
+      jest.spyOn(authService, 'validateUser').mockResolvedValue(user);
+      jest.spyOn(authService, 'getTokens').mockResolvedValue({
+        accessToken: 'access',
+        refreshToken: 'refresh',
+      });
+      jest.spyOn(authService, 'updateRefreshToken').mockResolvedValue(undefined);
+
+      const result = await authService.userLogin(credentials);
+
+      expect(result.user).toEqual(user);
+      expect(result.tokens).toBeInstanceOf(TokenPair);
+      expect(result.tokens.accessToken).toBe('access');
+      expect(result.tokens.refreshToken).toBe('refresh');
+    });
+
+    it('should throw UnauthorizedException for invalid credentials', async () => {
+      const credentials = new AuthCredentials();
+      credentials.email = 'user@example.com';
+      credentials.password = 'wrong';
+
+      jest.spyOn(authService, 'validateUser').mockResolvedValue(null);
+
+      await expect(authService.userLogin(credentials)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException if user is not REGULAR role', async () => {
+      const credentials = new AuthCredentials();
+      credentials.email = 'admin@example.com';
+      credentials.password = 'password';
+
+      const user = new User();
+      user.id = '1';
+      user.email = 'admin@example.com';
+      user.password = 'hashedpassword';
+      user.role = UserRole.PLATFORM_ADMIN;
+      user.emailVerified = true;
+
+      jest.spyOn(authService, 'validateUser').mockResolvedValue(user);
+
+      await expect(authService.userLogin(credentials)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException if email is not verified', async () => {
+      const credentials = new AuthCredentials();
+      credentials.email = 'user@example.com';
+      credentials.password = 'password';
+
+      const user = new User();
+      user.id = '1';
+      user.email = 'user@example.com';
+      user.password = 'hashedpassword';
+      user.role = UserRole.REGULAR;
+      user.emailVerified = false;
+
+      jest.spyOn(authService, 'validateUser').mockResolvedValue(user);
+
+      await expect(authService.userLogin(credentials)).rejects.toThrow(
+        'Email address not verified',
+      );
+    });
+  });
+
+  describe('getTokens', () => {
+    it('should return access and refresh tokens', async () => {
+      const result = await authService.getTokens(
+        'user-1',
+        'user@example.com',
+        UserRole.REGULAR,
+        false,
+        'user',
+      );
+
+      expect(result).toHaveProperty('accessToken');
+      expect(result).toHaveProperty('refreshToken');
+      expect(typeof result.accessToken).toBe('string');
+      expect(typeof result.refreshToken).toBe('string');
+    });
+  });
+
+  describe('decodeRefreshToken', () => {
+    it('should throw UnauthorizedException for invalid token', async () => {
+      await expect(
+        authService.decodeRefreshToken('invalid-token', 'user'),
+      ).rejects.toThrow(UnauthorizedException);
     });
   });
 });

--- a/test/modules/auth/auth.service.spec.ts
+++ b/test/modules/auth/auth.service.spec.ts
@@ -157,7 +157,7 @@ describe('AuthService', () => {
     it('should throw UnauthorizedException if user is not found', async () => {
       jest.spyOn(usersService, 'findById').mockResolvedValue(null);
       await expect(
-        authService.refreshToken('some-refresh-token'),
+        authService.refreshToken('some-refresh-token', 'platform-admin'),
       ).rejects.toThrow(UnauthorizedException);
     });
 
@@ -175,7 +175,7 @@ describe('AuthService', () => {
       jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
 
       await expect(
-        authService.refreshToken('some-refresh-token'),
+        authService.refreshToken('some-refresh-token', 'platform-admin'),
       ).rejects.toThrow(UnauthorizedException);
     });
 
@@ -200,7 +200,10 @@ describe('AuthService', () => {
         .spyOn(authService, 'updateRefreshToken')
         .mockResolvedValue(undefined);
 
-      const result = await authService.refreshToken('some-refresh-token');
+      const result = await authService.refreshToken(
+        'some-refresh-token',
+        'platform-admin',
+      );
 
       expect(result.user).toEqual(user);
       expect(result.tokens).toBeInstanceOf(TokenPair);

--- a/test/modules/auth/jwt-admin.strategy.spec.ts
+++ b/test/modules/auth/jwt-admin.strategy.spec.ts
@@ -1,0 +1,89 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtAdminStrategy } from '../../../src/modules/auth/strategies/jwt.strategy';
+import { UsersService } from '../../../src/modules/auth/users.service';
+import { UserRole } from '../../../src/modules/auth/entities/user.entity';
+import { mockUser } from '../../helpers/mock-user.helper';
+
+describe('JwtAdminStrategy', () => {
+  let strategy: JwtAdminStrategy;
+  let usersService: jest.Mocked<UsersService>;
+
+  beforeEach(() => {
+    usersService = {
+      findById: jest.fn(),
+    } as any;
+
+    const configService = {
+      get: jest.fn((key: string, defaultValue?: any) => {
+        const config: Record<string, any> = {
+          JWT_SECRET: 'test-jwt-secret-key-that-is-at-least-32-chars-long',
+          'app.name': 'PrismaCV',
+        };
+        return config[key] ?? defaultValue;
+      }),
+    } as unknown as ConfigService;
+
+    strategy = new JwtAdminStrategy(configService, usersService);
+  });
+
+  describe('validate', () => {
+    it('should return user for valid PLATFORM_ADMIN payload', async () => {
+      const adminUser = mockUser({
+        id: '1',
+        role: UserRole.PLATFORM_ADMIN,
+        isMasterAdmin: true,
+      });
+      usersService.findById.mockResolvedValue(adminUser);
+
+      const result = await strategy.validate({
+        sub: '1',
+        email: 'admin@example.com',
+        role: UserRole.PLATFORM_ADMIN,
+      });
+
+      expect(result).toEqual(adminUser);
+      expect(usersService.findById).toHaveBeenCalledWith('1');
+    });
+
+    it('should throw UnauthorizedException if payload role is not PLATFORM_ADMIN', async () => {
+      await expect(
+        strategy.validate({
+          sub: '1',
+          email: 'user@example.com',
+          role: UserRole.REGULAR,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(usersService.findById).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedException if user not found in DB', async () => {
+      usersService.findById.mockResolvedValue(null);
+
+      await expect(
+        strategy.validate({
+          sub: '1',
+          email: 'admin@example.com',
+          role: UserRole.PLATFORM_ADMIN,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException if DB user role differs from payload', async () => {
+      const regularUser = mockUser({
+        id: '1',
+        role: UserRole.REGULAR,
+      });
+      usersService.findById.mockResolvedValue(regularUser);
+
+      await expect(
+        strategy.validate({
+          sub: '1',
+          email: 'admin@example.com',
+          role: UserRole.PLATFORM_ADMIN,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/test/modules/auth/jwt-auth.guard.spec.ts
+++ b/test/modules/auth/jwt-auth.guard.spec.ts
@@ -1,9 +1,9 @@
-import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { JwtAuthGuard } from '../../../src/modules/auth/guards/jwt-auth.guard';
+import { JwtAdminAuthGuard } from '../../../src/modules/auth/guards/jwt-auth.guard';
 
-describe('JwtAuthGuard', () => {
-  let guard: JwtAuthGuard;
+describe('JwtAdminAuthGuard', () => {
+  let guard: JwtAdminAuthGuard;
   let reflector: jest.Mocked<Reflector>;
 
   beforeEach(() => {
@@ -11,7 +11,7 @@ describe('JwtAuthGuard', () => {
       getAllAndOverride: jest.fn(),
     } as any;
 
-    guard = new JwtAuthGuard(reflector);
+    guard = new JwtAdminAuthGuard(reflector);
   });
 
   describe('canActivate', () => {
@@ -32,9 +32,11 @@ describe('JwtAuthGuard', () => {
       const context = createMockExecutionContext();
       reflector.getAllAndOverride.mockReturnValue(false);
 
-      // Mock the parent class canActivate
       const superCanActivateSpy = jest
-        .spyOn(Object.getPrototypeOf(JwtAuthGuard.prototype), 'canActivate')
+        .spyOn(
+          Object.getPrototypeOf(JwtAdminAuthGuard.prototype),
+          'canActivate',
+        )
         .mockReturnValue(true);
 
       const result = guard.canActivate(context);
@@ -50,47 +52,37 @@ describe('JwtAuthGuard', () => {
     it('should return user when authentication is successful', () => {
       const mockUser = { id: '1', email: 'test@example.com' };
 
-      const result = guard.handleRequest(null, mockUser);
+      const result = guard.handleRequest(null, mockUser, null);
 
       expect(result).toEqual(mockUser);
     });
 
-    it('should throw ForbiddenException when user is not provided', () => {
-      expect(() => guard.handleRequest(null, null)).toThrow(ForbiddenException);
-      expect(() => guard.handleRequest(null, null)).toThrow(
-        'Access denied - valid JWT token required',
+    it('should throw UnauthorizedException when user is not provided', () => {
+      expect(() => guard.handleRequest(null, null, null)).toThrow(
+        UnauthorizedException,
       );
     });
 
-    it('should throw ForbiddenException when user is undefined', () => {
-      expect(() => guard.handleRequest(null, undefined)).toThrow(
-        ForbiddenException,
-      );
-      expect(() => guard.handleRequest(null, undefined)).toThrow(
-        'Access denied - valid JWT token required',
+    it('should throw UnauthorizedException when user is undefined', () => {
+      expect(() => guard.handleRequest(null, undefined, null)).toThrow(
+        UnauthorizedException,
       );
     });
 
-    it('should throw ForbiddenException when there is an error', () => {
+    it('should throw UnauthorizedException when there is an error', () => {
       const mockUser = { id: '1', email: 'test@example.com' };
       const error = new Error('Token expired');
 
-      expect(() => guard.handleRequest(error, mockUser)).toThrow(
-        ForbiddenException,
-      );
-      expect(() => guard.handleRequest(error, mockUser)).toThrow(
-        'Access denied - valid JWT token required',
+      expect(() => guard.handleRequest(error, mockUser, null)).toThrow(
+        UnauthorizedException,
       );
     });
 
-    it('should throw ForbiddenException when both error and no user', () => {
+    it('should throw UnauthorizedException when both error and no user', () => {
       const error = new Error('Invalid token');
 
-      expect(() => guard.handleRequest(error, null)).toThrow(
-        ForbiddenException,
-      );
-      expect(() => guard.handleRequest(error, null)).toThrow(
-        'Access denied - valid JWT token required',
+      expect(() => guard.handleRequest(error, null, null)).toThrow(
+        UnauthorizedException,
       );
     });
   });

--- a/test/modules/auth/jwt-user-auth.guard.spec.ts
+++ b/test/modules/auth/jwt-user-auth.guard.spec.ts
@@ -1,0 +1,89 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { JwtUserAuthGuard } from '../../../src/modules/auth/guards/jwt-user-auth.guard';
+
+describe('JwtUserAuthGuard', () => {
+  let guard: JwtUserAuthGuard;
+
+  beforeEach(() => {
+    guard = new JwtUserAuthGuard();
+  });
+
+  describe('canActivate', () => {
+    it('should call super.canActivate (no @Public bypass)', () => {
+      const context = createMockExecutionContext();
+
+      const superCanActivateSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(JwtUserAuthGuard.prototype),
+          'canActivate',
+        )
+        .mockReturnValue(true);
+
+      const result = guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(superCanActivateSpy).toHaveBeenCalledWith(context);
+
+      superCanActivateSpy.mockRestore();
+    });
+  });
+
+  describe('handleRequest', () => {
+    it('should return user when authentication is successful', () => {
+      const mockUser = { id: '1', email: 'user@example.com', role: 'REGULAR' };
+
+      const result = guard.handleRequest(null, mockUser, null);
+
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw UnauthorizedException when user is not provided', () => {
+      expect(() => guard.handleRequest(null, null, null)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException when user is undefined', () => {
+      expect(() => guard.handleRequest(null, undefined, null)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should throw UnauthorizedException with default message when no info', () => {
+      expect(() => guard.handleRequest(null, null, null)).toThrow(
+        'Authentication required — valid JWT token required',
+      );
+    });
+
+    it('should throw UnauthorizedException with info message when provided', () => {
+      expect(() =>
+        guard.handleRequest(null, null, { message: 'jwt expired' }),
+      ).toThrow('jwt expired');
+    });
+
+    it('should throw UnauthorizedException when there is an error even with valid user', () => {
+      const mockUser = { id: '1', email: 'user@example.com' };
+      const error = new Error('Token expired');
+
+      expect(() => guard.handleRequest(error, mockUser, null)).toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+});
+
+function createMockExecutionContext(): ExecutionContext {
+  return {
+    getHandler: jest.fn().mockReturnValue({}),
+    getClass: jest.fn().mockReturnValue({}),
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue({}),
+      getResponse: jest.fn().mockReturnValue({}),
+    }),
+    getArgs: jest.fn(),
+    getArgByIndex: jest.fn(),
+    switchToRpc: jest.fn(),
+    switchToWs: jest.fn(),
+    getType: jest.fn(),
+  } as unknown as ExecutionContext;
+}

--- a/test/modules/auth/jwt-user-auth.guard.spec.ts
+++ b/test/modules/auth/jwt-user-auth.guard.spec.ts
@@ -13,10 +13,7 @@ describe('JwtUserAuthGuard', () => {
       const context = createMockExecutionContext();
 
       const superCanActivateSpy = jest
-        .spyOn(
-          Object.getPrototypeOf(JwtUserAuthGuard.prototype),
-          'canActivate',
-        )
+        .spyOn(Object.getPrototypeOf(JwtUserAuthGuard.prototype), 'canActivate')
         .mockReturnValue(true);
 
       const result = guard.canActivate(context);

--- a/test/modules/auth/jwt-user.strategy.spec.ts
+++ b/test/modules/auth/jwt-user.strategy.spec.ts
@@ -1,0 +1,89 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtUserStrategy } from '../../../src/modules/auth/strategies/jwt-user.strategy';
+import { UsersService } from '../../../src/modules/auth/users.service';
+import { UserRole } from '../../../src/modules/auth/entities/user.entity';
+import { mockUser } from '../../helpers/mock-user.helper';
+
+describe('JwtUserStrategy', () => {
+  let strategy: JwtUserStrategy;
+  let usersService: jest.Mocked<UsersService>;
+
+  beforeEach(() => {
+    usersService = {
+      findById: jest.fn(),
+    } as any;
+
+    const configService = {
+      get: jest.fn((key: string, defaultValue?: any) => {
+        const config: Record<string, any> = {
+          JWT_SECRET: 'test-jwt-secret-key-that-is-at-least-32-chars-long',
+          'app.name': 'PrismaCV',
+        };
+        return config[key] ?? defaultValue;
+      }),
+    } as unknown as ConfigService;
+
+    strategy = new JwtUserStrategy(configService, usersService);
+  });
+
+  describe('validate', () => {
+    it('should return user for valid REGULAR payload', async () => {
+      const regularUser = mockUser({
+        id: '1',
+        role: UserRole.REGULAR,
+        emailVerified: true,
+      });
+      usersService.findById.mockResolvedValue(regularUser);
+
+      const result = await strategy.validate({
+        sub: '1',
+        email: 'user@example.com',
+        role: UserRole.REGULAR,
+      });
+
+      expect(result).toEqual(regularUser);
+      expect(usersService.findById).toHaveBeenCalledWith('1');
+    });
+
+    it('should throw UnauthorizedException if payload role is not REGULAR', async () => {
+      await expect(
+        strategy.validate({
+          sub: '1',
+          email: 'admin@example.com',
+          role: UserRole.PLATFORM_ADMIN,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(usersService.findById).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedException if user not found in DB', async () => {
+      usersService.findById.mockResolvedValue(null);
+
+      await expect(
+        strategy.validate({
+          sub: '1',
+          email: 'user@example.com',
+          role: UserRole.REGULAR,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException if DB user role differs from payload', async () => {
+      const adminUser = mockUser({
+        id: '1',
+        role: UserRole.PLATFORM_ADMIN,
+      });
+      usersService.findById.mockResolvedValue(adminUser);
+
+      await expect(
+        strategy.validate({
+          sub: '1',
+          email: 'user@example.com',
+          role: UserRole.REGULAR,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/test/modules/auth/otp.controller.spec.ts
+++ b/test/modules/auth/otp.controller.spec.ts
@@ -43,6 +43,11 @@ describe('OtpController', () => {
 
     const mockAuthService = {
       verifyPasswordResetOtp: jest.fn(),
+      getTokens: jest.fn().mockResolvedValue({
+        accessToken: 'mock-access-token',
+        refreshToken: 'mock-refresh-token',
+      }),
+      updateRefreshToken: jest.fn().mockResolvedValue(undefined),
     };
 
     const mockAuthMapper = {
@@ -93,6 +98,8 @@ describe('OtpController', () => {
       expect(result).toEqual({
         message: 'Email verified successfully',
         user: mockUserProfile,
+        accessToken: 'mock-access-token',
+        refreshToken: 'mock-refresh-token',
       });
     });
 

--- a/test/modules/auth/user-auth.controller.spec.ts
+++ b/test/modules/auth/user-auth.controller.spec.ts
@@ -6,8 +6,10 @@ import { AuthMapper } from '../../../src/modules/auth/mappers/auth.mapper';
 import { UserLoginRequestDto } from '../../../src/modules/auth/dto/request/user-login.request.dto';
 import { UserSignupRequestDto } from '../../../src/modules/auth/dto/request/user-signup.request.dto';
 import { UserAuthResponseDto } from '../../../src/modules/auth/dto/response/user-auth.response.dto';
+import { UserLoginResponseDto } from '../../../src/modules/auth/dto/response/user-login.response.dto';
 import { UserProfileResponseDto } from '../../../src/modules/auth/dto/response/user-profile.response.dto';
 import { User, UserRole } from '../../../src/modules/auth/entities/user.entity';
+import { TokenPair } from '../../../src/modules/auth/entities/token-pair.entity';
 import { AuthCredentials } from '../../../src/modules/auth/entities/auth-credentials.entity';
 
 describe('UserAuthController', () => {
@@ -22,7 +24,7 @@ describe('UserAuthController', () => {
     name: 'Regular User',
     role: UserRole.REGULAR,
     refreshToken: null,
-    emailVerified: false,
+    emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),
   });
@@ -32,13 +34,24 @@ describe('UserAuthController', () => {
     email: 'user@example.com',
     name: 'Regular User',
     role: UserRole.REGULAR,
-    emailVerified: false,
+    emailVerified: true,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
 
+  const mockTokens: TokenPair = Object.assign(new TokenPair(), {
+    accessToken: 'mock-access-token',
+    refreshToken: 'mock-refresh-token',
+  });
+
   const mockUserAuthResponse: UserAuthResponseDto = {
     user: mockUserProfile,
+  };
+
+  const mockUserLoginResponse: UserLoginResponseDto = {
+    user: mockUserProfile,
+    accessToken: 'mock-access-token',
+    refreshToken: 'mock-refresh-token',
   };
 
   beforeEach(async () => {
@@ -51,6 +64,7 @@ describe('UserAuthController', () => {
       signupRequestToEntity: jest.fn(),
       loginRequestToCredentials: jest.fn(),
       userToUserAuthResponse: jest.fn(),
+      userToUserLoginResponse: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -73,7 +87,7 @@ describe('UserAuthController', () => {
   });
 
   describe('login', () => {
-    it('should login user successfully with DTOs and mapper', async () => {
+    it('should login user successfully and return tokens', async () => {
       const loginDto: UserLoginRequestDto = {
         email: 'user@example.com',
         password: 'user123',
@@ -86,8 +100,9 @@ describe('UserAuthController', () => {
       authMapper.loginRequestToCredentials.mockReturnValue(credentials);
       authService.userLogin.mockResolvedValue({
         user: mockRegularUser,
+        tokens: mockTokens,
       });
-      authMapper.userToUserAuthResponse.mockReturnValue(mockUserAuthResponse);
+      authMapper.userToUserLoginResponse.mockReturnValue(mockUserLoginResponse);
 
       const result = await controller.login(loginDto);
 
@@ -95,10 +110,13 @@ describe('UserAuthController', () => {
         loginDto,
       );
       expect(authService.userLogin).toHaveBeenCalledWith(credentials);
-      expect(authMapper.userToUserAuthResponse).toHaveBeenCalledWith(
+      expect(authMapper.userToUserLoginResponse).toHaveBeenCalledWith(
         mockRegularUser,
+        mockTokens,
       );
-      expect(result).toEqual(mockUserAuthResponse);
+      expect(result).toEqual(mockUserLoginResponse);
+      expect(result.accessToken).toBeDefined();
+      expect(result.refreshToken).toBeDefined();
     });
 
     it('should handle mapper error during user login', async () => {

--- a/test/modules/auth/user-auth.controller.spec.ts
+++ b/test/modules/auth/user-auth.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { UserAuthController } from '../../../src/modules/auth/user-auth.controller';
 import { AuthService } from '../../../src/modules/auth/auth.service';
 import { AuthMapper } from '../../../src/modules/auth/mappers/auth.mapper';
@@ -58,6 +58,10 @@ describe('UserAuthController', () => {
     const mockAuthService = {
       userLogin: jest.fn(),
       userSignup: jest.fn(),
+      forgotPassword: jest.fn(),
+      resetPassword: jest.fn(),
+      changePassword: jest.fn(),
+      refreshToken: jest.fn(),
     };
 
     const mockAuthMapper = {
@@ -184,6 +188,114 @@ describe('UserAuthController', () => {
       );
       expect(authMapper.signupRequestToEntity).toHaveBeenCalledWith(signupDto);
       expect(authService.userSignup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('should call authService.forgotPassword with email', async () => {
+      const forgotDto = { email: 'user@example.com' };
+      const expectedResponse = {
+        message: 'If the email exists, an OTP has been sent.',
+      };
+
+      authService.forgotPassword.mockResolvedValue(expectedResponse);
+
+      const result = await controller.forgotPassword(forgotDto);
+
+      expect(authService.forgotPassword).toHaveBeenCalledWith(
+        'user@example.com',
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('should call authService.resetPassword with token and passwords', async () => {
+      const resetDto = {
+        resetToken: 'valid-token',
+        newPassword: 'newPass123',
+        confirmPassword: 'newPass123',
+      };
+      const expectedResponse = { message: 'Password reset successfully' };
+
+      authService.resetPassword.mockResolvedValue(expectedResponse);
+
+      const result = await controller.resetPassword(resetDto);
+
+      expect(authService.resetPassword).toHaveBeenCalledWith(
+        'valid-token',
+        'newPass123',
+        'newPass123',
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe('changePassword', () => {
+    it('should call authService.changePassword with user id from JWT', async () => {
+      const changeDto = {
+        currentPassword: 'oldPass123',
+        newPassword: 'newPass123',
+        confirmPassword: 'newPass123',
+      };
+      const expectedResponse = { message: 'Password changed successfully' };
+
+      authService.changePassword.mockResolvedValue(expectedResponse);
+
+      const result = await controller.changePassword(
+        changeDto,
+        mockRegularUser,
+      );
+
+      expect(authService.changePassword).toHaveBeenCalledWith(
+        '2',
+        'oldPass123',
+        'newPass123',
+        'newPass123',
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe('refresh', () => {
+    it('should refresh user token successfully', async () => {
+      const refreshDto = { refreshToken: 'valid-refresh-token' };
+
+      authService.refreshToken.mockResolvedValue({
+        user: mockRegularUser,
+        tokens: mockTokens,
+      });
+      authMapper.userToUserLoginResponse.mockReturnValue(mockUserLoginResponse);
+
+      const result = await controller.refresh(refreshDto);
+
+      expect(authService.refreshToken).toHaveBeenCalledWith(
+        'valid-refresh-token',
+        'user',
+      );
+      expect(authMapper.userToUserLoginResponse).toHaveBeenCalledWith(
+        mockRegularUser,
+        mockTokens,
+      );
+      expect(result).toEqual(mockUserLoginResponse);
+    });
+
+    it('should throw BadRequestException when refresh token is missing', async () => {
+      await expect(
+        controller.refresh({ refreshToken: '' } as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw UnauthorizedException for invalid refresh token', async () => {
+      const refreshDto = { refreshToken: 'invalid-token' };
+
+      authService.refreshToken.mockRejectedValue(
+        new UnauthorizedException('Invalid or expired refresh token'),
+      );
+
+      await expect(controller.refresh(refreshDto)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 });

--- a/test/modules/oauth/oauth.service.spec.ts
+++ b/test/modules/oauth/oauth.service.spec.ts
@@ -1,0 +1,175 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import { OAuthService } from '../../../src/modules/oauth/services/oauth.service';
+import { UsersService } from '../../../src/modules/auth/users.service';
+import { AuthService } from '../../../src/modules/auth/auth.service';
+import { User, UserRole } from '../../../src/modules/auth/entities/user.entity';
+import { TokenPair } from '../../../src/modules/auth/entities/token-pair.entity';
+import { mockUser } from '../../helpers/mock-user.helper';
+
+describe('OAuthService', () => {
+  let oauthService: OAuthService;
+  let usersService: jest.Mocked<UsersService>;
+  let authService: jest.Mocked<AuthService>;
+
+  const baseOAuthData = {
+    profile: {
+      provider: 'google',
+      providerId: 'google-123',
+      email: 'user@example.com',
+      name: 'OAuth User',
+      picture: 'https://example.com/photo.jpg',
+    },
+    accessToken: 'oauth-access-token',
+    refreshToken: 'oauth-refresh-token',
+    expiresAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OAuthService,
+        {
+          provide: UsersService,
+          useValue: {
+            findByProvider: jest.fn(),
+            findByEmail: jest.fn(),
+            createOAuthUser: jest.fn(),
+            linkOAuthAccount: jest.fn(),
+            updateOAuthMetadata: jest.fn(),
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            getTokens: jest.fn(),
+            updateRefreshToken: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    oauthService = module.get<OAuthService>(OAuthService);
+    usersService = module.get(UsersService);
+    authService = module.get(AuthService);
+  });
+
+  describe('authenticate', () => {
+    it('should authenticate existing OAuth user and return tokens', async () => {
+      const existingUser = mockUser({
+        id: '1',
+        email: 'user@example.com',
+        role: UserRole.REGULAR,
+        provider: 'google',
+        providerId: 'google-123',
+      });
+
+      usersService.findByProvider.mockResolvedValue(existingUser);
+      usersService.updateOAuthMetadata.mockResolvedValue(existingUser);
+      authService.getTokens.mockResolvedValue({
+        accessToken: 'jwt-access',
+        refreshToken: 'jwt-refresh',
+      });
+      authService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await oauthService.authenticate(baseOAuthData);
+
+      expect(result.user).toEqual(existingUser);
+      expect(result.tokens).toBeInstanceOf(TokenPair);
+      expect(result.tokens.accessToken).toBe('jwt-access');
+      expect(result.tokens.refreshToken).toBe('jwt-refresh');
+      expect(authService.getTokens).toHaveBeenCalledWith(
+        '1',
+        'user@example.com',
+        UserRole.REGULAR,
+        false,
+        'user',
+      );
+    });
+
+    it('should create new OAuth user when not found', async () => {
+      const newUser = mockUser({
+        id: '2',
+        email: 'user@example.com',
+        role: UserRole.REGULAR,
+      });
+
+      usersService.findByProvider.mockResolvedValue(null);
+      usersService.findByEmail.mockResolvedValue(null);
+      usersService.createOAuthUser.mockResolvedValue(newUser);
+      usersService.updateOAuthMetadata.mockResolvedValue(newUser);
+      authService.getTokens.mockResolvedValue({
+        accessToken: 'jwt-access',
+        refreshToken: 'jwt-refresh',
+      });
+      authService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await oauthService.authenticate(baseOAuthData);
+
+      expect(usersService.createOAuthUser).toHaveBeenCalledWith(
+        baseOAuthData.profile,
+      );
+      expect(result.tokens.accessToken).toBe('jwt-access');
+    });
+
+    it('should link OAuth to existing email-password user', async () => {
+      const existingUser = mockUser({
+        id: '3',
+        email: 'user@example.com',
+        role: UserRole.REGULAR,
+        provider: null,
+      });
+      const linkedUser = mockUser({
+        ...existingUser,
+        provider: 'google',
+        providerId: 'google-123',
+      });
+
+      usersService.findByProvider.mockResolvedValue(null);
+      usersService.findByEmail.mockResolvedValue(existingUser);
+      usersService.linkOAuthAccount.mockResolvedValue(linkedUser);
+      usersService.updateOAuthMetadata.mockResolvedValue(linkedUser);
+      authService.getTokens.mockResolvedValue({
+        accessToken: 'jwt-access',
+        refreshToken: 'jwt-refresh',
+      });
+      authService.updateRefreshToken.mockResolvedValue(undefined);
+
+      const result = await oauthService.authenticate(baseOAuthData);
+
+      expect(usersService.linkOAuthAccount).toHaveBeenCalled();
+      expect(result.tokens.accessToken).toBe('jwt-access');
+    });
+
+    it('should throw ConflictException when email exists with different OAuth provider', async () => {
+      const existingUser = mockUser({
+        id: '4',
+        email: 'user@example.com',
+        provider: 'linkedin',
+      });
+
+      usersService.findByProvider.mockResolvedValue(null);
+      usersService.findByEmail.mockResolvedValue(existingUser);
+
+      await expect(oauthService.authenticate(baseOAuthData)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('should throw UnauthorizedException for non-REGULAR users', async () => {
+      const adminUser = mockUser({
+        id: '5',
+        email: 'admin@example.com',
+        role: UserRole.PLATFORM_ADMIN,
+      });
+
+      usersService.findByProvider.mockResolvedValue(adminUser);
+      usersService.updateOAuthMetadata.mockResolvedValue(adminUser);
+
+      await expect(oauthService.authenticate(baseOAuthData)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(authService.getTokens).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/modules/oauth/oauth.service.spec.ts
+++ b/test/modules/oauth/oauth.service.spec.ts
@@ -3,7 +3,7 @@ import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { OAuthService } from '../../../src/modules/oauth/services/oauth.service';
 import { UsersService } from '../../../src/modules/auth/users.service';
 import { AuthService } from '../../../src/modules/auth/auth.service';
-import { User, UserRole } from '../../../src/modules/auth/entities/user.entity';
+import { UserRole } from '../../../src/modules/auth/entities/user.entity';
 import { TokenPair } from '../../../src/modules/auth/entities/token-pair.entity';
 import { mockUser } from '../../helpers/mock-user.helper';
 

--- a/test/modules/oauth/oauth.service.spec.ts
+++ b/test/modules/oauth/oauth.service.spec.ts
@@ -156,7 +156,7 @@ describe('OAuthService', () => {
       );
     });
 
-    it('should throw UnauthorizedException for non-REGULAR users', async () => {
+    it('should throw UnauthorizedException for existing provider user with non-REGULAR role', async () => {
       const adminUser = mockUser({
         id: '5',
         email: 'admin@example.com',
@@ -164,12 +164,30 @@ describe('OAuthService', () => {
       });
 
       usersService.findByProvider.mockResolvedValue(adminUser);
-      usersService.updateOAuthMetadata.mockResolvedValue(adminUser);
 
       await expect(oauthService.authenticate(baseOAuthData)).rejects.toThrow(
         UnauthorizedException,
       );
+      expect(usersService.updateOAuthMetadata).not.toHaveBeenCalled();
       expect(authService.getTokens).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedException before linking if existing email user is non-REGULAR', async () => {
+      const adminUser = mockUser({
+        id: '6',
+        email: 'admin@example.com',
+        role: UserRole.PLATFORM_ADMIN,
+        provider: null,
+      });
+
+      usersService.findByProvider.mockResolvedValue(null);
+      usersService.findByEmail.mockResolvedValue(adminUser);
+
+      await expect(oauthService.authenticate(baseOAuthData)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(usersService.linkOAuthAccount).not.toHaveBeenCalled();
+      expect(usersService.updateOAuthMetadata).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Problem

The existing JWT system only issued tokens to **Platform Admins**. Regular users never received JWTs — their auth endpoints required an existing JWT to call (a bootstrapping impossibility). OAuth flows also returned no tokens. This meant regular users had no independent authentication, and all user-facing endpoints were effectively admin-operated.

Additionally, there was no audience segregation — a single JWT strategy meant admin and user tokens were interchangeable, and an IDOR vulnerability in change-password allowed any user to change another user's password by passing a `userId` in the request body.

## Solution

Dual-audience JWT architecture with independent user authentication, audience-segregated tokens, and standard JWT security hardening.

## What Changed

### Phase 1 — JWT Infrastructure Hardening
- **Startup secret validation** via `OnModuleInit` — app crashes if `JWT_SECRET` or `JWT_REFRESH_SECRET` is missing or < 32 characters
- **`getTokens()` now includes standard claims**: `iss` (issuer), `aud` (audience: `platform-admin` | `user`), `jti` (unique token ID via `randomUUID()`), explicit `HS256` algorithm
- **Removed confusing `DEFAULT_EXPIRES_IN: '7d'`** from jwt.constants.ts — only `ACCESS_TOKEN: '15m'` and `REFRESH_TOKEN: '7d'` remain
- **Consistent `ConfigService` usage** — replaced all `process.env.JWT_*` with `configService.get()`

### Phase 2 — 403 → 401 Fix
- `JwtAdminAuthGuard.handleRequest()` now throws `UnauthorizedException` (401) instead of `ForbiddenException` (403) for unauthenticated requests, and forwards `info?.message` from Passport for meaningful error messages

### Phase 3 — User Token Issuance
- **User auth endpoints marked `@Public()`**: login, signup, forgot-password, reset-password — these no longer require a pre-existing JWT
- **`userLogin()` returns tokens** (`{ user, tokens: TokenPair }`) with an email verification gate — unverified users get 401 with a clear message
- **New `UserLoginResponseDto`** with `user`, `accessToken`, `refreshToken` fields
- **New `userToUserLoginResponse()` mapper method**

### Phase 4 — Audience-Segregated Strategies & IDOR Fix
- **`JwtStrategy` → `JwtAdminStrategy`** (strategy name: `jwt-admin`) with `audience: 'platform-admin'`, `issuer`, `algorithms: ['HS256']`, and DB role validation
- **New `JwtUserStrategy`** (strategy name: `jwt-user`) with `audience: 'user'` and DB role validation — both strategies verify the token payload role AND the current DB role to catch stale tokens from role changes
- **`JwtAuthGuard` → `JwtAdminAuthGuard`** using `AuthGuard('jwt-admin')`
- **New `JwtUserAuthGuard`** using `AuthGuard('jwt-user')` — deliberately has **no** `@Public()` bypass (always authenticates)
- **IDOR fix on change-password**: uses `@GetUser()` decorator to extract user ID from JWT `sub` claim instead of accepting `userId` from request body. The `userId` field has been removed from `ChangePasswordRequestDto`
- **Global guard updated** in `app.module.ts` to use `JwtAdminAuthGuard`

### Phase 5 — OAuth Token Issuance & Refresh Split
- **OAuth now returns JWT tokens** — `OAuthService.authenticate()` issues tokens with `aud: 'user'` after user creation/lookup. Non-REGULAR users are rejected with `UnauthorizedException`
- **Refresh endpoints split**: `POST /auth/admin/refresh` (validates `platform-admin` audience) and `POST /auth/user/refresh` (validates `user` audience)
- **`decodeRefreshToken()` enforces audience** — verifies `aud`, `iss`, and `algorithms: ['HS256']` on the refresh token

### Phase 6 — OTP Verify Issues Tokens
- `POST /otp/verify-signup` now issues JWT tokens immediately after email verification — no extra login round-trip needed

## Files Changed (35 files, +1347 / -226)

### Source (24 files)
| File | Change |
|---|---|
| `auth.service.ts` | `OnModuleInit`, `getTokens()` with claims, `userLogin()` tokens + email gate, `decodeRefreshToken()` audience enforcement |
| `user-auth.controller.ts` | `@Public()` decorators, IDOR fix on change-password, user refresh endpoint |
| `otp.controller.ts` | `@Public()` on all endpoints, verify-signup issues tokens |
| `auth.controller.ts` | Refresh route → `/auth/admin/refresh`, audience parameter |
| `jwt.strategy.ts` | Renamed to `JwtAdminStrategy`, audience/issuer/algorithm validation, DB role check |
| `jwt-user.strategy.ts` | **New** — `JwtUserStrategy` with `aud: 'user'` |
| `jwt-auth.guard.ts` | Renamed to `JwtAdminAuthGuard`, 401 fix, info forwarding |
| `jwt-user-auth.guard.ts` | **New** — no `@Public()` bypass |
| `user-login.response.dto.ts` | **New** — user login response with tokens |
| `change-password.request.dto.ts` | Removed `userId` field (IDOR fix) |
| `otp-verification.response.dto.ts` | Added `accessToken`, `refreshToken` fields |
| `oauth-callback.response.dto.ts` | Added `accessToken`, `refreshToken` fields |
| `oauth.service.ts` | Injects `AuthService`, issues tokens, rejects non-REGULAR users |
| `oauth.controller.ts` | Callbacks return tokens |
| `oauth.module.ts` | Imports `AuthModule`, removed duplicate `PrismaService` |
| `google.strategy.ts` / `linkedin.strategy.ts` | Updated return types |
| `auth.module.ts` | Registered new strategies/guards, `algorithm: 'HS256'` |
| `app.module.ts` | `APP_GUARD` → `JwtAdminAuthGuard` |
| `auth.mapper.ts` | Added `userToUserLoginResponse()` |
| `jwt.constants.ts` | Removed stale `DEFAULT_EXPIRES_IN` / `DEFAULT_REFRESH_EXPIRES_IN` |
| `app.config.ts` | Updated fallbacks to use `JWT_EXPIRATION` constants |
| `transform.interceptor.ts` / `base.mapper.ts` | Minor ESLint auto-fixes |

### Tests (11 files)
| File | Change |
|---|---|
| `jwt-user-auth.guard.spec.ts` | **New** — 6 tests: canActivate delegation, handleRequest error/info/user scenarios |
| `jwt-admin.strategy.spec.ts` | **New** — 4 tests: payload role check, DB role check, user not found |
| `jwt-user.strategy.spec.ts` | **New** — 4 tests: payload role check, DB role check, user not found |
| `oauth.service.spec.ts` | **New** — 5 tests: existing user, new user, link account, conflict, role rejection |
| `auth.mapper.spec.ts` | **New** — 12 tests: all mapper methods including new `userToUserLoginResponse` |
| `auth.service.spec.ts` | Extended — onModuleInit (4 tests), userLogin (4 tests), getTokens, decodeRefreshToken |
| `user-auth.controller.spec.ts` | Extended — forgotPassword, resetPassword, changePassword (IDOR), refresh with audience |
| `auth.controller.spec.ts` | Updated refresh calls with `'platform-admin'` audience arg |
| `otp.controller.spec.ts` | Added `getTokens`/`updateRefreshToken` mocks, token assertions |
| `jwt-auth.guard.spec.ts` | Updated for `JwtAdminAuthGuard` rename and `UnauthorizedException` |
| `auth-refresh.e2e-spec.ts` | Updated route from `/auth/refresh` to `/auth/admin/refresh` |

### Test Results
- **Unit tests**: 143/143 passing (was 95 — added 48 new tests)
- **E2e tests**: 7/7 passing
- **Build**: clean
- **Lint**: clean

## No DB Migration Needed

All changes are code-only. `emailVerified`, `refreshToken`, and `role` fields already exist in the Prisma schema. New JWT claims (`iss`, `aud`, `jti`) live in the token payload, not the database.

## How to Verify

1. **Startup validation**: Remove `JWT_SECRET` env var → app should crash with clear error
2. **User signup flow**: `POST /auth/user/signup` (no JWT) → OTP email → `POST /otp/verify-signup` → tokens returned with `aud: user`
3. **User login**: `POST /auth/user/login` → tokens with `aud: user`; unverified email → 401
4. **Admin login**: `POST /auth/admin/login` → tokens with `aud: platform-admin`
5. **Cross-audience rejection**: admin token on `POST /auth/user/change-password` → 401; user token on `POST /auth/admin/create` → 401
6. **IDOR fixed**: `POST /auth/user/change-password` ignores any `userId` in body, uses JWT `sub`
7. **Refresh segregation**: `POST /auth/admin/refresh` rejects user tokens; `POST /auth/user/refresh` rejects admin tokens
8. **OAuth**: Google/LinkedIn callbacks → `{ user, accessToken, refreshToken }`
9. **Decode a token** (jwt.io) → confirm `iss`, `aud`, `jti`, `alg: HS256`