### PR TITLE
fix: exclude prisma dir from tsconfig.build to fix dist output path

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "prisma", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary
- `prisma/seed.ts` was included in the TypeScript build compilation, causing `tsc` to compute a common root directory and output files under `dist/src/` instead of `dist/`
- This resulted in `Cannot find module '/app/dist/main.js'` at container startup
- Adding `"prisma"` to the `exclude` array in `tsconfig.build.json` fixes the output path

## Test plan
- [x] Verified locally: `nest build` produces `dist/main.js` directly
- [x] Built Docker image and confirmed `node dist/main.js` starts NestJS successfully
- [x] Already deployed via release branch (v1.6.2) and confirmed working in production