### PR TITLE
ci: trigger Coolify deployment after Docker image publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Deploy to Coolify
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
-          curl -sf "${{ secrets.COOLIFY_WEBHOOK_URL }}" || { echo "Coolify deploy trigger failed"; exit 1; }
+          curl -sf -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" "${{ secrets.COOLIFY_WEBHOOK_URL }}" || { echo "Coolify deploy trigger failed"; exit 1; }
 
       - name: Release Summary
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,11 @@ jobs:
             ghcr.io/${{ steps.repo.outputs.lowercase }}:${{ steps.semantic.outputs.new_release_version }}
             ghcr.io/${{ steps.repo.outputs.lowercase }}:latest
 
+      - name: Deploy to Coolify
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          curl -sf "${{ secrets.COOLIFY_WEBHOOK_URL }}" || { echo "Coolify deploy trigger failed"; exit 1; }
+
       - name: Release Summary
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "prisma", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary
- Adds a step to the release workflow that calls the Coolify webhook URL after the Docker image is successfully built and pushed
- Requires `COOLIFY_WEBHOOK_URL` secret to be configured in repo settings

## Test plan
- [ ] Add `COOLIFY_WEBHOOK_URL` secret in GitHub repo settings
- [ ] Merge to main, then to release — verify Coolify redeploy is triggered after image push