### PR TITLE
fix: make OAuth endpoints public and redirect to frontend

### DIFF
--- a/src/modules/oauth/oauth.controller.ts
+++ b/src/modules/oauth/oauth.controller.ts
@@ -9,6 +9,7 @@ import {
   BadRequestException,
   HttpStatus,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   ApiTags,
   ApiOperation,
@@ -32,15 +33,30 @@ import { LinkedInCvService } from './services/linkedin-cv.service';
 @ApiBearerAuth('JWT-auth')
 @Controller('oauth')
 export class OAuthController {
+  private readonly frontendUrl: string;
+
   constructor(
     private readonly authMapper: AuthMapper,
     private readonly linkedInCvService: LinkedInCvService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.frontendUrl = (
+      this.configService.get<string>('CORS_ORIGIN') ?? 'http://localhost:3001'
+    ).replace(/\/$/, '');
+  }
+
+  private buildOAuthRedirectUrl(
+    response: OAuthCallbackResponseDto,
+  ): string {
+    const payload = Buffer.from(JSON.stringify(response)).toString('base64url');
+    return `${this.frontendUrl}/auth/oauth-callback#token=${payload}`;
+  }
 
   /* ---------------------------
         LINKEDIN AUTH FLOW
   ---------------------------- */
 
+  @Public()
   @Get('linkedin')
   @UseGuards(LinkedInAuthGuard)
   @ApiOperation({
@@ -51,10 +67,6 @@ export class OAuthController {
   @ApiResponse({
     status: HttpStatus.FOUND,
     description: 'Redirects to LinkedIn OAuth page',
-  })
-  @ApiResponse({
-    status: HttpStatus.FORBIDDEN,
-    description: 'Forbidden - Missing or invalid JWT token',
   })
   async linkedinAuth() {
     // Handled by Passport
@@ -73,13 +85,14 @@ export class OAuthController {
       refreshToken: tokens.refreshToken,
     };
 
-    return res.status(HttpStatus.OK).json(response);
+    return res.redirect(HttpStatus.FOUND, this.buildOAuthRedirectUrl(response));
   }
 
   /* ---------------------------
             GOOGLE AUTH FLOW
   ---------------------------- */
 
+  @Public()
   @Get('google')
   @UseGuards(GoogleAuthGuard)
   @ApiOperation({
@@ -108,7 +121,7 @@ export class OAuthController {
       refreshToken: tokens.refreshToken,
     };
 
-    return res.status(HttpStatus.OK).json(response);
+    return res.redirect(HttpStatus.FOUND, this.buildOAuthRedirectUrl(response));
   }
 
   /* ---------------------------

--- a/src/modules/oauth/oauth.controller.ts
+++ b/src/modules/oauth/oauth.controller.ts
@@ -40,9 +40,41 @@ export class OAuthController {
     private readonly linkedInCvService: LinkedInCvService,
     private readonly configService: ConfigService,
   ) {
-    this.frontendUrl = (
-      this.configService.get<string>('CORS_ORIGIN') ?? 'http://localhost:3001'
-    ).replace(/\/$/, '');
+    this.frontendUrl = this.resolveFrontendUrl();
+  }
+
+  private resolveFrontendUrl(): string {
+    const defaultFrontendUrl = 'http://localhost:3001';
+    const configuredFrontendUrl =
+      this.configService.get<string>('FRONTEND_URL');
+
+    if (configuredFrontendUrl?.trim()) {
+      try {
+        return new URL(configuredFrontendUrl.trim()).origin;
+      } catch {
+        return defaultFrontendUrl;
+      }
+    }
+
+    const corsOrigin = this.configService.get<string>('CORS_ORIGIN')?.trim();
+    if (!corsOrigin || corsOrigin === '*') {
+      return defaultFrontendUrl;
+    }
+
+    const origins = corsOrigin
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0);
+
+    if (origins.length !== 1) {
+      return defaultFrontendUrl;
+    }
+
+    try {
+      return new URL(origins[0]).origin;
+    } catch {
+      return defaultFrontendUrl;
+    }
   }
 
   private buildOAuthRedirectUrl(

--- a/test/modules/oauth/oauth.controller.spec.ts
+++ b/test/modules/oauth/oauth.controller.spec.ts
@@ -49,7 +49,10 @@ describe('OAuthController', () => {
         {
           provide: ConfigService,
           useValue: {
-            get: jest.fn().mockReturnValue('http://localhost:3001'),
+            get: jest.fn((key: string) => {
+              if (key === 'FRONTEND_URL') return 'http://localhost:3001';
+              return undefined;
+            }),
           },
         },
       ],

--- a/test/modules/oauth/oauth.controller.spec.ts
+++ b/test/modules/oauth/oauth.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { OAuthController } from '../../../src/modules/oauth/oauth.controller';
 import { AuthMapper } from '../../../src/modules/auth/mappers/auth.mapper';
 import { LinkedInCvService } from '../../../src/modules/oauth/services/linkedin-cv.service';
@@ -45,6 +46,12 @@ describe('OAuthController', () => {
             importForUser: jest.fn(),
           },
         },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockReturnValue('http://localhost:3001'),
+          },
+        },
       ],
     }).compile();
 
@@ -58,47 +65,39 @@ describe('OAuthController', () => {
   });
 
   describe('linkedinCallback', () => {
-    it('should return user data and tokens', async () => {
+    it('should redirect to frontend with encoded tokens', async () => {
       const req = {
         user: { user: testUser, tokens: testTokens },
       } as any;
       const res = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
+        redirect: jest.fn(),
       } as any;
 
       await controller.linkedinCallback(req, res);
 
       expect(authMapper.userToUserAuthResponse).toHaveBeenCalledWith(testUser);
-      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accessToken: 'access-token',
-          refreshToken: 'refresh-token',
-        }),
+      expect(res.redirect).toHaveBeenCalledWith(
+        HttpStatus.FOUND,
+        expect.stringContaining('/auth/oauth-callback#token='),
       );
     });
   });
 
   describe('googleCallback', () => {
-    it('should return user data and tokens', async () => {
+    it('should redirect to frontend with encoded tokens', async () => {
       const req = {
         user: { user: testUser, tokens: testTokens },
       } as any;
       const res = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
+        redirect: jest.fn(),
       } as any;
 
       await controller.googleCallback(req, res);
 
       expect(authMapper.userToUserAuthResponse).toHaveBeenCalledWith(testUser);
-      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accessToken: 'access-token',
-          refreshToken: 'refresh-token',
-        }),
+      expect(res.redirect).toHaveBeenCalledWith(
+        HttpStatus.FOUND,
+        expect.stringContaining('/auth/oauth-callback#token='),
       );
     });
   });


### PR DESCRIPTION
## Problem

Google and LinkedIn OAuth login buttons on the frontend did nothing. Two issues:

1. **Global `JwtAdminAuthGuard` blocked OAuth initiation** — `GET /oauth/google` and `GET /oauth/linkedin` lacked `@Public()`, so unauthenticated users got 401 before the Passport redirect ran.

2. **OAuth callbacks returned JSON instead of redirecting** — `googleCallback()` and `linkedinCallback()` used `res.json()`, leaving users on a blank JSON page instead of returning them to the frontend.

## Fix

- Add `@Public()` to both OAuth initiation endpoints (`GET /oauth/google`, `GET /oauth/linkedin`)
- Change both callbacks to `res.redirect(302, frontendUrl + '/auth/oauth-callback#token=' + base64url(payload))`
- Inject `ConfigService` to read `CORS_ORIGIN` for the frontend redirect URL
- Tokens are passed in the URL fragment (`#`) so they never appear in server logs

## Frontend counterpart

PR [prismacv-ui#126](https://github.com/Integral-X/prismacv-ui/pull/126) adds the `/auth/oauth-callback` page that decodes the fragment, persists the session cookies, and redirects to `/dashboard`.