### PR TITLE
fix: correct OAuth callback response shape and LinkedIn import auth

### DIFF
--- a/src/modules/oauth/dto/oauth-callback.response.dto.ts
+++ b/src/modules/oauth/dto/oauth-callback.response.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { UserAuthResponseDto } from '@/modules/auth/dto/response/user-auth.response.dto';
+import { UserProfileResponseDto } from '@/modules/auth/dto/response/user-profile.response.dto';
 
 export class OAuthCallbackResponseDto {
   @ApiProperty({
     description: 'User profile information',
-    type: UserAuthResponseDto,
+    type: UserProfileResponseDto,
   })
-  user!: UserAuthResponseDto;
+  user!: UserProfileResponseDto;
 
   @ApiProperty({ description: 'JWT access token (15 min TTL)' })
   accessToken!: string;

--- a/src/modules/oauth/oauth.controller.ts
+++ b/src/modules/oauth/oauth.controller.ts
@@ -6,7 +6,6 @@ import {
   Res,
   Post,
   Body,
-  BadRequestException,
   HttpStatus,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -20,7 +19,9 @@ import {
 import { Request, Response } from 'express';
 import { LinkedInAuthGuard } from './guards/linkedin-auth.guard';
 import { GoogleAuthGuard } from './guards/google-auth.guard';
+import { JwtUserAuthGuard } from '@/modules/auth/guards/jwt-user-auth.guard';
 import { Public } from '@/common/decorators/public.decorator';
+import { GetUser } from '@/common/decorators/get-user.decorator';
 import { OAuthCallbackResponseDto } from './dto/oauth-callback.response.dto';
 import { LinkedinImportRequestDto } from './dto/linkedin-import.request.dto';
 import { LinkedinCvResponseDto } from './dto/linkedin-cv.response.dto';
@@ -63,8 +64,8 @@ export class OAuthController {
 
     const origins = corsOrigin
       .split(',')
-      .map((origin) => origin.trim())
-      .filter((origin) => origin.length > 0);
+      .map(origin => origin.trim())
+      .filter(origin => origin.length > 0);
 
     if (origins.length !== 1) {
       return defaultFrontendUrl;
@@ -77,9 +78,7 @@ export class OAuthController {
     }
   }
 
-  private buildOAuthRedirectUrl(
-    response: OAuthCallbackResponseDto,
-  ): string {
+  private buildOAuthRedirectUrl(response: OAuthCallbackResponseDto): string {
     const payload = Buffer.from(JSON.stringify(response)).toString('base64url');
     return `${this.frontendUrl}/auth/oauth-callback#token=${payload}`;
   }
@@ -112,7 +111,7 @@ export class OAuthController {
     const { user, tokens } = req.user as { user: User; tokens: TokenPair };
 
     const response: OAuthCallbackResponseDto = {
-      user: this.authMapper.userToUserAuthResponse(user),
+      user: this.authMapper.userToProfileResponse(user),
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
     };
@@ -148,7 +147,7 @@ export class OAuthController {
     const { user, tokens } = req.user as { user: User; tokens: TokenPair };
 
     const response: OAuthCallbackResponseDto = {
-      user: this.authMapper.userToUserAuthResponse(user),
+      user: this.authMapper.userToProfileResponse(user),
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
     };
@@ -160,6 +159,8 @@ export class OAuthController {
         LINKEDIN CV IMPORT
   ---------------------------- */
 
+  @Public()
+  @UseGuards(JwtUserAuthGuard)
   @Post('linkedin/import')
   @ApiOperation({
     summary: 'Import LinkedIn profile data for CV generation',
@@ -180,20 +181,9 @@ export class OAuthController {
     description: 'Conflict - LinkedIn account not connected or missing token',
   })
   async importLinkedInProfile(
-    @Req() req: Request,
+    @GetUser() user: User,
     @Body() body: LinkedinImportRequestDto,
   ): Promise<LinkedinCvResponseDto> {
-    const authUser =
-      (req.user as { id?: string; userId?: string; sub?: string } | undefined)
-        ?.id ??
-      (req.user as { id?: string; userId?: string; sub?: string } | undefined)
-        ?.userId ??
-      (req.user as { id?: string; userId?: string; sub?: string } | undefined)
-        ?.sub;
-    if (!authUser) {
-      throw new BadRequestException('Authenticated user is required');
-    }
-
-    return this.linkedInCvService.importForUser(authUser, body.handleOrUrl);
+    return this.linkedInCvService.importForUser(user.id, body.handleOrUrl);
   }
 }

--- a/test/e2e/linkedin-import.e2e-spec.ts
+++ b/test/e2e/linkedin-import.e2e-spec.ts
@@ -2,10 +2,14 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from './../../src/app.module';
 import { INestApplication } from '@nestjs/common';
+import { PrismaService } from './../../src/config/prisma.service';
 
 describe('LinkedIn Import URL Validation (e2e)', () => {
   let app: INestApplication;
   let accessToken: string;
+
+  const testUserEmail = 'e2e-linkedin-import@prismacv.test';
+  const testUserPassword = 'Test1234!';
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,20 +19,37 @@ describe('LinkedIn Import URL Validation (e2e)', () => {
     app = moduleFixture.createNestApplication();
     await app.init();
 
-    // Login to get an access token
-    const adminEmail =
-      process.env.MASTER_ADMIN_EMAIL?.trim() ?? 'admin@example.com';
-    const adminPassword = process.env.MASTER_ADMIN_PASSWORD ?? 'admin';
+    // Create & verify a regular user so we can obtain a user-audience JWT
+    const prisma = app.get(PrismaService);
+    const bcrypt = await import('bcryptjs');
+    const { uuidv7 } = await import('uuidv7');
+
+    await prisma.user.upsert({
+      where: { email: testUserEmail },
+      update: { emailVerified: true },
+      create: {
+        id: uuidv7(),
+        email: testUserEmail,
+        password: await bcrypt.hash(testUserPassword, 10),
+        name: 'E2E LinkedIn Test User',
+        role: 'REGULAR',
+        isMasterAdmin: false,
+        emailVerified: true,
+        provider: null,
+      },
+    });
 
     const loginResponse = await request(app.getHttpServer())
-      .post('/auth/admin/login')
-      .send({ email: adminEmail, password: adminPassword })
+      .post('/auth/user/login')
+      .send({ email: testUserEmail, password: testUserPassword })
       .expect(200);
 
     accessToken = loginResponse.body.accessToken;
   });
 
   afterAll(async () => {
+    const prisma = app.get(PrismaService);
+    await prisma.user.deleteMany({ where: { email: testUserEmail } });
     await app.close();
   });
 

--- a/test/modules/oauth/oauth.controller.spec.ts
+++ b/test/modules/oauth/oauth.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, HttpStatus } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { OAuthController } from '../../../src/modules/oauth/oauth.controller';
 import { AuthMapper } from '../../../src/modules/auth/mappers/auth.mapper';
@@ -32,7 +32,7 @@ describe('OAuthController', () => {
         {
           provide: AuthMapper,
           useValue: {
-            userToUserAuthResponse: jest.fn().mockReturnValue({
+            userToProfileResponse: jest.fn().mockReturnValue({
               id: '1',
               email: 'user@example.com',
               name: 'Test User',
@@ -78,7 +78,7 @@ describe('OAuthController', () => {
 
       await controller.linkedinCallback(req, res);
 
-      expect(authMapper.userToUserAuthResponse).toHaveBeenCalledWith(testUser);
+      expect(authMapper.userToProfileResponse).toHaveBeenCalledWith(testUser);
       expect(res.redirect).toHaveBeenCalledWith(
         HttpStatus.FOUND,
         expect.stringContaining('/auth/oauth-callback#token='),
@@ -97,7 +97,7 @@ describe('OAuthController', () => {
 
       await controller.googleCallback(req, res);
 
-      expect(authMapper.userToUserAuthResponse).toHaveBeenCalledWith(testUser);
+      expect(authMapper.userToProfileResponse).toHaveBeenCalledWith(testUser);
       expect(res.redirect).toHaveBeenCalledWith(
         HttpStatus.FOUND,
         expect.stringContaining('/auth/oauth-callback#token='),
@@ -110,40 +110,15 @@ describe('OAuthController', () => {
       const mockResponse = { source: {}, profile: {} } as any;
       linkedInCvService.importForUser.mockResolvedValue(mockResponse);
 
-      const req = { user: { id: 'user-1' } } as any;
       const body = { handleOrUrl: 'john-doe' };
 
-      const result = await controller.importLinkedInProfile(req, body);
+      const result = await controller.importLinkedInProfile(testUser, body);
 
       expect(linkedInCvService.importForUser).toHaveBeenCalledWith(
-        'user-1',
+        '1',
         'john-doe',
       );
       expect(result).toBe(mockResponse);
-    });
-
-    it('should throw BadRequestException when no authenticated user', async () => {
-      const req = { user: undefined } as any;
-      const body = { handleOrUrl: 'john-doe' };
-
-      await expect(controller.importLinkedInProfile(req, body)).rejects.toThrow(
-        BadRequestException,
-      );
-    });
-
-    it('should resolve userId from sub field', async () => {
-      const mockResponse = { source: {}, profile: {} } as any;
-      linkedInCvService.importForUser.mockResolvedValue(mockResponse);
-
-      const req = { user: { sub: 'user-sub' } } as any;
-      const body = { handleOrUrl: 'jane-doe' };
-
-      await controller.importLinkedInProfile(req, body);
-
-      expect(linkedInCvService.importForUser).toHaveBeenCalledWith(
-        'user-sub',
-        'jane-doe',
-      );
     });
   });
 });


### PR DESCRIPTION
## Problem
OAuth login via Google/LinkedIn was broken due to two bugs:

**1. Double-nested user object in callback response** — `userToUserAuthResponse()` wraps profile in `{ user: ... }`, producing `{ user: { user: {...} } }`. UI expects flat profile at `payload.user`, so session persistence threw and silently redirected to login.

**2. LinkedIn import blocked for regular users** — No `@Public()`/`@UseGuards(JwtUserAuthGuard)` on the endpoint. Global `JwtAdminAuthGuard` required `audience: platform-admin`; regular users (audience: user) always got 401.

## Changes
- Change `OAuthCallbackResponseDto.user` type to `UserProfileResponseDto` (flat)
- Use `userToProfileResponse()` in both callbacks
- Add `@Public()` + `@UseGuards(JwtUserAuthGuard)` + `@GetUser()` to LinkedIn import
- Update tests
 