### PR TITLE
fix: add missing migration for platform tables

### DIFF
--- a/prisma/migrations/20260503230000_add_platform_tables/migration.sql
+++ b/prisma/migrations/20260503230000_add_platform_tables/migration.sql
@@ -1,0 +1,148 @@
+-- CreateEnum
+CREATE TYPE "JobStatus" AS ENUM ('SAVED', 'APPLIED', 'INTERVIEW', 'OFFER', 'REJECTED');
+
+-- CreateEnum
+CREATE TYPE "InterviewDifficulty" AS ENUM ('EASY', 'MEDIUM', 'HARD');
+
+-- CreateTable
+CREATE TABLE "jobs" (
+    "id" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "title" TEXT NOT NULL,
+    "company" TEXT NOT NULL,
+    "url" TEXT,
+    "location" TEXT,
+    "isRemote" BOOLEAN NOT NULL DEFAULT false,
+    "salaryMin" INTEGER,
+    "salaryMax" INTEGER,
+    "salaryCurrency" TEXT,
+    "status" "JobStatus" NOT NULL DEFAULT 'SAVED',
+    "appliedAt" TIMESTAMP(3),
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "jobs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "job_notes" (
+    "id" UUID NOT NULL,
+    "jobId" UUID NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "job_notes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "skill_categories" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "icon" TEXT,
+
+    CONSTRAINT "skill_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "role_skill_maps" (
+    "id" UUID NOT NULL,
+    "role" TEXT NOT NULL,
+    "skillName" TEXT NOT NULL,
+    "categoryId" UUID NOT NULL,
+    "importance" INTEGER NOT NULL DEFAULT 3,
+    "description" TEXT,
+
+    CONSTRAINT "role_skill_maps_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "user_skill_progress" (
+    "id" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "skillName" TEXT NOT NULL,
+    "level" INTEGER NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'not_started',
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "user_skill_progress_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "learning_resources" (
+    "id" UUID NOT NULL,
+    "skillName" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "platform" TEXT NOT NULL,
+    "difficulty" TEXT NOT NULL DEFAULT 'beginner',
+    "duration" TEXT,
+    "isFree" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "learning_resources_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "interview_questions" (
+    "id" UUID NOT NULL,
+    "question" TEXT NOT NULL,
+    "sampleAnswer" TEXT,
+    "category" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "difficulty" "InterviewDifficulty" NOT NULL DEFAULT 'MEDIUM',
+    "tips" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "interview_questions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "jobs_userId_status_idx" ON "jobs"("userId", "status");
+
+-- CreateIndex
+CREATE INDEX "jobs_userId_updatedAt_idx" ON "jobs"("userId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "job_notes_jobId_createdAt_idx" ON "job_notes"("jobId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "skill_categories_name_key" ON "skill_categories"("name");
+
+-- CreateIndex
+CREATE INDEX "role_skill_maps_role_idx" ON "role_skill_maps"("role");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "role_skill_maps_role_skillName_key" ON "role_skill_maps"("role", "skillName");
+
+-- CreateIndex
+CREATE INDEX "user_skill_progress_userId_idx" ON "user_skill_progress"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_skill_progress_userId_skillName_key" ON "user_skill_progress"("userId", "skillName");
+
+-- CreateIndex
+CREATE INDEX "learning_resources_skillName_idx" ON "learning_resources"("skillName");
+
+-- CreateIndex
+CREATE INDEX "interview_questions_role_category_idx" ON "interview_questions"("role", "category");
+
+-- CreateIndex
+CREATE INDEX "interview_questions_difficulty_idx" ON "interview_questions"("difficulty");
+
+-- AddForeignKey
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "job_notes" ADD CONSTRAINT "job_notes_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "jobs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "role_skill_maps" ADD CONSTRAINT "role_skill_maps_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "skill_categories"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_skill_progress" ADD CONSTRAINT "user_skill_progress_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Adds migration for jobs, skills, interview tables that were missing from the feature PR (#162). Creates enums (JobStatus, InterviewDifficulty) and tables (jobs, job_notes, skill_categories, role_skill_maps, user_skill_progress, learning_resources, interview_questions) with all indexes and foreign keys.