### PR TITLE
fix: add shadow database URL to prisma drift check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:password@localhost:5432/prismacv_test
 
       - name: Run Prisma migration drift check
-        run: npx prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --exit-code
+        run: npx prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --shadow-database-url postgresql://postgres:password@localhost:5432/postgres --exit-code
 
       - name: Run linting
         run: npm run lint


### PR DESCRIPTION
## Summary
- add `--shadow-database-url` to the release workflow Prisma drift check command
- fix CI failure where `prisma migrate diff --from-migrations` requires a shadow database URL

## Test plan
- [x] `pnpm prettier --check .github/workflows/release.yml`
- [ ] Re-run release workflow and confirm drift check passes