### PR TITLE
chore: strip billing/metrics/queue, simplify to rule-based AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,27 +3,18 @@
 [![Main Pipeline](https://github.com/Integral-X/prismacv-backend/actions/workflows/main.yml/badge.svg)](https://github.com/Integral-X/prismacv-backend/actions/workflows/main.yml)
 [![PR Pipeline](https://github.com/Integral-X/prismacv-backend/actions/workflows/pr.yml/badge.svg)](https://github.com/Integral-X/prismacv-backend/actions/workflows/pr.yml)
 
-Backend API for PrismaCV: CV management, AI-assisted career tooling, billing, auth, and platform services.
-
-## Current Status
-
-- Feature-ready backend scope is implemented for CVs, jobs, skills, ATS, grammar, and cover letters.
-- AI supports both built-in heuristics and OpenAI provider routing behind Unleash flags.
-- Per-feature monthly AI quotas are enforced with failure-safe quota refund on provider errors.
-- Billing is live via Stripe (checkout, portal, webhook, plan gating).
-- Operational tooling is in place: Sentry, Prometheus `/metrics`, health checks, and optional BullMQ/Redis queueing.
+Backend API for the PrismaCV platform — AI-powered CV building, job application tracking, skill gap analysis, and career management.
 
 ## Tech Stack
 
 - **Runtime**: Node.js 20 + TypeScript
 - **Framework**: NestJS 11
 - **Database**: PostgreSQL + Prisma ORM 6
-- **Auth**: JWT (user/admin), refresh tokens, Google & LinkedIn OAuth
-- **AI**: Built-in providers + OpenAI (`AI_PROVIDER=openai`) with retries/timeouts/quotas
-- **Billing**: Stripe subscriptions + webhook idempotency
+- **Auth**: JWT (dual-audience: admin + user), Google & LinkedIn OAuth
+- **PDF Export**: Puppeteer (Chromium)
+- **AI**: Built-in rule-based analysis & optimization (no external LLM)
 - **Feature Flags**: Unleash
-- **Observability**: Winston logging (PII redaction), Sentry, Prometheus metrics
-- **Infrastructure**: Docker, health checks, optional BullMQ + Redis
+- **Security**: Helmet, rate limiting (Throttler), AllExceptionsFilter (no stack trace leaks)
 
 ## Getting Started
 
@@ -31,104 +22,99 @@ Backend API for PrismaCV: CV management, AI-assisted career tooling, billing, au
 git clone https://github.com/integral-x/prismacv-backend.git
 cd prismacv-backend
 npm install
-cp .env.example .env
-./start.sh
+cp .env.example .env    # fill in required values
+./start.sh              # starts Docker services + dev server
 ```
 
 Stop everything: `./stop.sh`
 
-## Environment Variables
+### Environment Variables
 
-Copy `.env.example` to `.env` and fill values for your environment. The complete list lives in `.env.example`; key groups are below.
+Copy `.env.example` to `.env` and fill in the values.
 
-### Core
+#### Core (required)
 
-| Variable                                      | Purpose                          |
-| --------------------------------------------- | -------------------------------- |
-| `NODE_ENV`, `PORT`, `API_PREFIX`              | Runtime mode and API host/prefix |
-| `DATABASE_URL`, `DATABASE_URL_TEST`           | Prisma PostgreSQL connections    |
-| `FRONTEND_URL`, `CORS_ORIGIN`, `DISABLE_CORS` | Frontend redirects and CORS      |
-| `APP_NAME`, `APP_VERSION`, `LOG_LEVEL`        | App identity and logging         |
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `NODE_ENV` | Environment | `production` |
+| `PORT` | Server port | `3210` |
+| `API_PREFIX` | Global route prefix | `api` |
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host:5432/prismacv` |
+| `JWT_SECRET` | Access token signing (≥ 32 chars) | *(random)* |
+| `JWT_REFRESH_SECRET` | Refresh token signing (≥ 32 chars) | *(random, different)* |
+| `ENCRYPTION_KEY` | OAuth token encryption (≥ 32 chars) | `openssl rand -base64 32` |
+| `MASTER_ADMIN_EMAIL` | Seed admin email | `admin@prismacv.com` |
+| `MASTER_ADMIN_PASSWORD` | Seed admin password | *(strong password)* |
+| `CORS_ORIGIN` | Allowed frontend origin(s) | `https://www.prismacv.com` |
+| `FRONTEND_URL` | Frontend URL for OAuth redirects | `https://www.prismacv.com` |
 
-### Auth and Security
+#### Email / OTP (required for user registration)
 
-| Variable                                                           | Purpose                               |
-| ------------------------------------------------------------------ | ------------------------------------- |
-| `JWT_SECRET`, `JWT_EXPIRES_IN`                                     | Access token signing and TTL          |
-| `JWT_REFRESH_SECRET`, `JWT_REFRESH_EXPIRES_IN`                     | Refresh token signing and TTL         |
-| `ENCRYPTION_KEY`                                                   | Encrypt OAuth provider tokens at rest |
-| `MASTER_ADMIN_EMAIL`, `MASTER_ADMIN_PASSWORD`, `MASTER_ADMIN_NAME` | Seed admin account                    |
-| `BCRYPT_ROUNDS`                                                    | Password hash cost                    |
-| `THROTTLE_TTL`, `THROTTLE_LIMIT`                                   | Global throttle settings              |
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `SMTP_HOST` | SMTP server | `smtp.gmail.com` |
+| `SMTP_PORT` | SMTP port | `587` |
+| `SMTP_USER` | SMTP username | `noreply@prismacv.com` |
+| `SMTP_PASS` | SMTP password / app password | *(app password)* |
+| `SMTP_FROM_NAME` | Sender display name | `PrismaCV` |
+| `SMTP_FROM_EMAIL` | Sender email | `noreply@prismacv.com` |
 
-### AI
+#### Google OAuth (optional — gracefully disabled if unset)
 
-| Variable                                            | Purpose                             |
-| --------------------------------------------------- | ----------------------------------- |
-| `AI_PROVIDER`, `OPENAI_API_KEY`, `AI_MODEL`         | Provider selection and model config |
-| `AI_MAX_RETRIES`, `AI_TIMEOUT_MS`, `AI_TEMPERATURE` | Provider reliability and behavior   |
-| `AI_MONTHLY_*_LIMIT`                                | Per-feature monthly quota limits    |
-| `AI_ANALYSIS_CACHE_TTL_SECONDS`                     | CV analysis cache expiration        |
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID | `*.apps.googleusercontent.com` |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret | *(from Google Cloud Console)* |
+| `GOOGLE_CALLBACK_URL` | OAuth callback URL | `https://api.prismacv.com/api/v1/oauth/google/callback` |
 
-### Billing
+#### LinkedIn OAuth (optional — gracefully disabled if unset)
 
-| Variable                                                        | Purpose                             |
-| --------------------------------------------------------------- | ----------------------------------- |
-| `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`                    | Stripe API and webhook verification |
-| `STRIPE_PRICE_PRO_MONTHLY`, `STRIPE_PRICE_PRO_YEARLY`           | Pro plan price IDs                  |
-| `STRIPE_PRICE_TEAM_MONTHLY`, `STRIPE_PRICE_TEAM_YEARLY`         | Team plan price IDs                 |
-| `BILLING_PLAN_CACHE_TTL_SECONDS`, `BILLING_WEBHOOK_CACHE_LIMIT` | Billing performance/safety controls |
+| Variable | Purpose | Example |
+| --- | --- | --- |
+| `LINKEDIN_CLIENT_ID` | LinkedIn OAuth client ID | *(from LinkedIn Dev Portal)* |
+| `LINKEDIN_CLIENT_SECRET` | LinkedIn OAuth client secret | *(from LinkedIn Dev Portal)* |
+| `LINKEDIN_CALLBACK_URL` | OAuth callback URL | `https://api.prismacv.com/api/v1/oauth/linkedin/callback` |
 
-### Email and OTP
+#### Optional
 
-| Variable                                                                 | Purpose                          |
-| ------------------------------------------------------------------------ | -------------------------------- |
-| `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`                       | SMTP transport                   |
-| `SMTP_FROM_NAME`, `SMTP_FROM_EMAIL`, `SUPPORT_EMAIL`                     | Email metadata                   |
-| `SMTP_SKIP_AUTH`                                                         | MailHog/local SMTP compatibility |
-| `OTP_EXPIRY_MINUTES`, `OTP_MAX_ATTEMPTS_*`, `RESET_TOKEN_EXPIRY_MINUTES` | OTP/password-reset policy        |
-| `MAILHOG_API_URL`, `MAILHOG_E2E`                                         | MailHog smoke-test controls      |
-
-### Feature Flags, Monitoring, and Queueing
-
-| Variable                                   | Purpose                          |
-| ------------------------------------------ | -------------------------------- |
-| `UNLEASH_*`                                | Runtime feature flag integration |
-| `SENTRY_DSN`, `SENTRY_*`                   | Error/trace monitoring           |
-| `QUEUE_ENABLED`, `QUEUE_NAME`, `REDIS_URL` | Optional background jobs         |
-
-### OAuth (Optional)
-
-If OAuth keys are omitted, providers stay disabled gracefully:
-
-- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL`
-- `LINKEDIN_CLIENT_ID`, `LINKEDIN_CLIENT_SECRET`, `LINKEDIN_CALLBACK_URL`, `LINKEDIN_API_TIMEOUT_MS`
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `JWT_EXPIRES_IN` | `15m` | Access token TTL |
+| `JWT_REFRESH_EXPIRES_IN` | `7d` | Refresh token TTL |
+| `BCRYPT_ROUNDS` | `12` | Password hash rounds |
+| `DISABLE_CORS` | `false` | Disable CORS (dev only) |
+| `UNLEASH_URL` | — | Unleash server URL (mock mode if unset) |
+| `UNLEASH_API_TOKEN` | — | Unleash server-side token |
+| `LOG_LEVEL` | `info` | Logging verbosity |
 
 ## API Documentation
 
-Swagger UI is available in non-production environments:
+Swagger UI available in development/staging:  
+[https://api.prismacv.com/api/docs](https://api.prismacv.com/api/docs)
 
-- [https://api.prismacv.com/api/docs](https://api.prismacv.com/api/docs)
-
-> Swagger is automatically disabled when `NODE_ENV=production`.
+> **Note**: Swagger is automatically disabled when `NODE_ENV=production`.
 
 ## Development
 
 ```bash
-npm run start:dev
-npm run build
-npm run lint
-npm run db:migrate
-npm run db:generate
+npm run start:dev       # watch mode
+npm run build           # compile
+npm run lint            # eslint --fix
+```
+
+### Database
+
+```bash
+npm run db:migrate      # prisma migrate dev
+npm run db:generate     # prisma generate
 ```
 
 ## Testing
 
 ```bash
-npm run test
-npm run test:e2e
-npm run test:e2e:mailhog
-npm run test:cov
+npm run test            # unit tests (190 specs)
+npm run test:e2e        # integration (requires postgres on :5433)
+npm run test:cov        # coverage report
 ```
 
 ## Docker
@@ -138,7 +124,7 @@ docker build -t prismacv-backend .
 docker run -p 3000:3000 --env-file .env prismacv-backend
 ```
 
-The image includes Chromium for PDF export and exposes health checks for container orchestration.
+Multi-stage build includes Chromium for PDF generation.
 
 ## License
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,16 +26,11 @@ model User {
   oauthAccessToken String?
   oauthRefreshToken String?
   oauthTokenExpiresAt DateTime?
-  stripeCustomerId String? @unique
-  plan          UserPlan  @default(FREE)
   linkedinCvImports LinkedinCvImport[]
   cvs               Cv[]
   jobs              Job[]
   skillProgress     UserSkillProgress[]
   coverLetters      CoverLetter[]
-  subscription      Subscription?
-  aiUsages          AiUsage[]
-  aiAnalysisCaches  AiAnalysisCache[]
 
   @@unique([provider, providerId])
   @@map("users")
@@ -78,12 +73,6 @@ enum OAuthProvider {
 enum UserRole {
   REGULAR
   PLATFORM_ADMIN
-}
-
-enum UserPlan {
-  FREE
-  PRO
-  TEAM
 }
 
 enum OtpPurpose {
@@ -173,7 +162,6 @@ model Cv {
   customSections CustomSection[]
   share          CvShare?
   coverLetters   CoverLetter[]
-  aiAnalysisCaches AiAnalysisCache[]
 
   @@unique([userId, slug])
   @@index([userId, status])
@@ -474,85 +462,4 @@ model CoverLetter {
 
   @@index([userId, updatedAt])
   @@map("cover_letters")
-}
-
-model Plan {
-  id                 String   @id @db.Uuid
-  code               UserPlan @unique
-  name               String
-  description        String?
-  priceMonthlyCents  Int?
-  priceYearlyCents   Int?
-  stripePriceMonthly String?
-  stripePriceYearly  String?
-  isActive           Boolean  @default(true)
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
-
-  subscriptions Subscription[]
-
-  @@map("plans")
-}
-
-model Subscription {
-  id                 String   @id @db.Uuid
-  userId             String   @unique @db.Uuid
-  planId             String   @db.Uuid
-  status             String   @default("inactive")
-  stripeSubscriptionId String? @unique
-  stripePriceId      String?
-  currentPeriodStart DateTime?
-  currentPeriodEnd   DateTime?
-  cancelAtPeriodEnd  Boolean  @default(false)
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  plan Plan @relation(fields: [planId], references: [id], onDelete: Restrict)
-
-  @@index([planId, status])
-  @@map("subscriptions")
-}
-
-enum AiUsageFeature {
-  CV_ANALYZE
-  CV_OPTIMIZE
-  GRAMMAR_CHECK
-  ATS_SCORE
-  COVER_LETTER_GENERATE
-}
-
-model AiUsage {
-  id          String         @id @db.Uuid
-  userId      String         @db.Uuid
-  feature     AiUsageFeature
-  periodStart DateTime
-  periodEnd   DateTime
-  callsUsed   Int            @default(0)
-  createdAt   DateTime       @default(now())
-  updatedAt   DateTime       @updatedAt
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@unique([userId, feature, periodStart, periodEnd])
-  @@index([userId, feature, periodEnd])
-  @@map("ai_usage")
-}
-
-model AiAnalysisCache {
-  id          String   @id @db.Uuid
-  userId      String   @db.Uuid
-  cvId        String   @db.Uuid
-  contentHash String
-  provider    String
-  analysis    Json
-  createdAt   DateTime @default(now())
-  expiresAt   DateTime
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  cv   Cv   @relation(fields: [cvId], references: [id], onDelete: Cascade)
-
-  @@unique([cvId, contentHash, provider])
-  @@index([userId, expiresAt])
-  @@map("ai_analysis_cache")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,9 +25,9 @@ import { InterviewModule } from './modules/interview/interview.module';
 import { AtsModule } from './modules/ats/ats.module';
 import { GrammarModule } from './modules/grammar/grammar.module';
 import { CoverLettersModule } from './modules/cover-letters/cover-letters.module';
-import { BillingModule } from './modules/billing/billing.module';
-import { MetricsModule } from './modules/metrics/metrics.module';
-import { QueueModule } from './modules/queue/queue.module';
+
+// Guards
+import { JwtAdminAuthGuard } from './modules/auth/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -71,11 +71,12 @@ import { QueueModule } from './modules/queue/queue.module';
     AtsModule,
     GrammarModule,
     CoverLettersModule,
-    BillingModule,
-    MetricsModule,
-    QueueModule,
   ],
   providers: [
+    {
+      provide: APP_GUARD,
+      useClass: JwtAdminAuthGuard,
+    },
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,

--- a/src/modules/ai/ai.controller.ts
+++ b/src/modules/ai/ai.controller.ts
@@ -17,13 +17,10 @@ import {
   ApiParam,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { UserPlan } from '@prisma/client';
 import { JwtUserAuthGuard } from '@/modules/auth/guards/jwt-user-auth.guard';
 import { GetUser } from '@/common/decorators/get-user.decorator';
 import { Public } from '@/common/decorators/public.decorator';
 import { User } from '@/modules/auth/entities/user.entity';
-import { RequiresPlan } from '@/modules/billing/decorators/requires-plan.decorator';
-import { RequiresPlanGuard } from '@/modules/billing/requires-plan.guard';
 import { AiService } from './ai.service';
 import {
   OptimizeCvRequestDto,
@@ -39,12 +36,8 @@ export class AiController {
   constructor(private readonly aiService: AiService) {}
 
   @Post('cv/:id/analyze')
-  @UseGuards(JwtUserAuthGuard, RequiresPlanGuard)
-  @RequiresPlan({
-    plans: [UserPlan.PRO, UserPlan.TEAM],
-    feature: 'ai_cv_analysis',
-  })
-  @Throttle({ default: { limit: 6, ttl: 60000 } })
+  @UseGuards(JwtUserAuthGuard)
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Analyze a CV',
@@ -62,12 +55,8 @@ export class AiController {
   }
 
   @Post('cv/:id/optimize')
-  @UseGuards(JwtUserAuthGuard, RequiresPlanGuard)
-  @RequiresPlan({
-    plans: [UserPlan.PRO, UserPlan.TEAM],
-    feature: 'ai_cv_optimization',
-  })
-  @Throttle({ default: { limit: 6, ttl: 60000 } })
+  @UseGuards(JwtUserAuthGuard)
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Optimize a CV for a job description',

--- a/src/modules/ats/ats.controller.ts
+++ b/src/modules/ats/ats.controller.ts
@@ -14,13 +14,8 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { UserPlan } from '@prisma/client';
 import { JwtUserAuthGuard } from '@/modules/auth/guards/jwt-user-auth.guard';
 import { Public } from '@/common/decorators/public.decorator';
-import { GetUser } from '@/common/decorators/get-user.decorator';
-import { User } from '@/modules/auth/entities/user.entity';
-import { RequiresPlan } from '@/modules/billing/decorators/requires-plan.decorator';
-import { RequiresPlanGuard } from '@/modules/billing/requires-plan.guard';
 import { AtsService } from './ats.service';
 import { AtsScoreRequestDto } from './dto/ats-score.request.dto';
 import { AtsScoreResponseDto } from './dto/ats-score.response.dto';
@@ -33,11 +28,7 @@ export class AtsController {
   constructor(private readonly atsService: AtsService) {}
 
   @Post('score')
-  @UseGuards(JwtUserAuthGuard, RequiresPlanGuard)
-  @RequiresPlan({
-    plans: [UserPlan.PRO, UserPlan.TEAM],
-    feature: 'ats_score',
-  })
+  @UseGuards(JwtUserAuthGuard)
   @Throttle({ default: { limit: 12, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
@@ -51,10 +42,7 @@ export class AtsController {
     description: 'ATS analysis result',
     type: AtsScoreResponseDto,
   })
-  async score(
-    @GetUser() user: User,
-    @Body() dto: AtsScoreRequestDto,
-  ): Promise<AtsScoreResponseDto> {
-    return this.atsService.analyze(dto, user.id);
+  score(@Body() dto: AtsScoreRequestDto): AtsScoreResponseDto {
+    return this.atsService.analyze(dto);
   }
 }

--- a/src/modules/ats/ats.module.ts
+++ b/src/modules/ats/ats.module.ts
@@ -1,11 +1,8 @@
 import { Module } from '@nestjs/common';
 import { AtsController } from './ats.controller';
 import { AtsService } from './ats.service';
-import { AiModule } from '@/modules/ai/ai.module';
-import { UnleashModule } from '@/modules/unleash/unleash.module';
 
 @Module({
-  imports: [AiModule, UnleashModule],
   controllers: [AtsController],
   providers: [AtsService],
   exports: [AtsService],

--- a/src/modules/ats/ats.service.ts
+++ b/src/modules/ats/ats.service.ts
@@ -1,11 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { AiUsageFeature } from '@prisma/client';
-import { AiUsageService } from '@/modules/ai/ai-usage.service';
-import { OpenAiProvider } from '@/modules/ai/providers/openai.provider';
-import { UnleashService } from '@/modules/unleash/unleash.service';
-import { AI_LLM_ATS_FLAG } from '@/modules/ai/ai-feature-flags';
-import { MetricsService } from '@/modules/metrics/metrics.service';
+import { Injectable } from '@nestjs/common';
 import { AtsScoreRequestDto } from './dto/ats-score.request.dto';
 import {
   AtsScoreResponseDto,
@@ -14,383 +7,73 @@ import {
 } from './dto/ats-score.response.dto';
 
 const STOP_WORDS = new Set([
-  'a',
-  'an',
-  'the',
-  'and',
-  'or',
-  'but',
-  'in',
-  'on',
-  'at',
-  'to',
-  'for',
-  'of',
-  'with',
-  'by',
-  'from',
-  'is',
-  'are',
-  'was',
-  'were',
-  'be',
-  'been',
-  'being',
-  'have',
-  'has',
-  'had',
-  'do',
-  'does',
-  'did',
-  'will',
-  'would',
-  'could',
-  'should',
-  'may',
-  'might',
-  'shall',
-  'can',
-  'need',
-  'dare',
-  'ought',
-  'used',
-  'this',
-  'that',
-  'these',
-  'those',
-  'i',
-  'me',
-  'my',
-  'myself',
-  'we',
-  'our',
-  'ours',
-  'ourselves',
-  'you',
-  'your',
-  'yours',
-  'yourself',
-  'yourselves',
-  'he',
-  'him',
-  'his',
-  'himself',
-  'she',
-  'her',
-  'hers',
-  'herself',
-  'it',
-  'its',
-  'itself',
-  'they',
-  'them',
-  'their',
-  'theirs',
-  'themselves',
-  'what',
-  'which',
-  'who',
-  'whom',
-  'when',
-  'where',
-  'why',
-  'how',
-  'all',
-  'each',
-  'every',
-  'both',
-  'few',
-  'more',
-  'most',
-  'other',
-  'some',
-  'such',
-  'no',
-  'nor',
-  'not',
-  'only',
-  'own',
-  'same',
-  'so',
-  'than',
-  'too',
-  'very',
-  'just',
-  'because',
-  'as',
-  'until',
-  'while',
-  'about',
-  'between',
-  'through',
-  'during',
-  'before',
-  'after',
-  'above',
-  'below',
-  'up',
-  'down',
-  'out',
-  'off',
-  'over',
-  'under',
-  'again',
-  'further',
-  'then',
-  'once',
-  'here',
-  'there',
-  'any',
-  'if',
-  'also',
-  'etc',
-  'per',
-  'able',
-  'must',
-  'well',
-  'including',
-  'within',
-  'using',
-  'work',
-  'working',
-  'experience',
-  'years',
-  'year',
-  'team',
-  'role',
-  'job',
-  'company',
-  'requirements',
-  'required',
-  'preferred',
-  'responsibilities',
-  'looking',
-  'join',
-  'strong',
-  'knowledge',
-  'understanding',
-  'minimum',
-  'plus',
-  'ideal',
-  'candidate',
-  'position',
-  'opportunity',
-  'based',
+  'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+  'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
+  'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+  'could', 'should', 'may', 'might', 'shall', 'can', 'need', 'dare',
+  'ought', 'used', 'this', 'that', 'these', 'those', 'i', 'me', 'my',
+  'myself', 'we', 'our', 'ours', 'ourselves', 'you', 'your', 'yours',
+  'yourself', 'yourselves', 'he', 'him', 'his', 'himself', 'she', 'her',
+  'hers', 'herself', 'it', 'its', 'itself', 'they', 'them', 'their',
+  'theirs', 'themselves', 'what', 'which', 'who', 'whom', 'when', 'where',
+  'why', 'how', 'all', 'each', 'every', 'both', 'few', 'more', 'most',
+  'other', 'some', 'such', 'no', 'nor', 'not', 'only', 'own', 'same',
+  'so', 'than', 'too', 'very', 'just', 'because', 'as', 'until', 'while',
+  'about', 'between', 'through', 'during', 'before', 'after', 'above',
+  'below', 'up', 'down', 'out', 'off', 'over', 'under', 'again', 'further',
+  'then', 'once', 'here', 'there', 'any', 'if', 'also', 'etc', 'per',
+  'able', 'must', 'well', 'including', 'within', 'using', 'work', 'working',
+  'experience', 'years', 'year', 'team', 'role', 'job', 'company',
+  'requirements', 'required', 'preferred', 'responsibilities', 'looking',
+  'join', 'strong', 'knowledge', 'understanding', 'minimum', 'plus',
+  'ideal', 'candidate', 'position', 'opportunity', 'based',
 ]);
 
 const TECHNICAL_TERMS = new Set([
-  'javascript',
-  'typescript',
-  'python',
-  'java',
-  'c#',
-  'c++',
-  'ruby',
-  'go',
-  'rust',
-  'swift',
-  'kotlin',
-  'php',
-  'scala',
-  'r',
-  'matlab',
-  'perl',
-  'react',
-  'angular',
-  'vue',
-  'svelte',
-  'nextjs',
-  'next.js',
-  'nuxt',
-  'node.js',
-  'nodejs',
-  'express',
-  'nestjs',
-  'django',
-  'flask',
-  'fastapi',
-  'spring',
-  'spring boot',
-  '.net',
-  'rails',
-  'laravel',
-  'aws',
-  'azure',
-  'gcp',
-  'docker',
-  'kubernetes',
-  'k8s',
-  'terraform',
-  'jenkins',
-  'github actions',
-  'ci/cd',
-  'cicd',
-  'postgresql',
-  'mysql',
-  'mongodb',
-  'redis',
-  'elasticsearch',
-  'kafka',
-  'rabbitmq',
-  'graphql',
-  'rest',
-  'restful',
-  'grpc',
-  'microservices',
-  'sql',
-  'nosql',
-  'dynamodb',
-  'cassandra',
-  'oracle',
-  'html',
-  'css',
-  'sass',
-  'scss',
-  'tailwind',
-  'bootstrap',
-  'webpack',
-  'vite',
-  'babel',
-  'eslint',
-  'prettier',
-  'git',
-  'jira',
-  'confluence',
-  'figma',
-  'sketch',
-  'agile',
-  'scrum',
-  'kanban',
-  'devops',
-  'sre',
-  'machine learning',
-  'ml',
-  'ai',
-  'deep learning',
-  'nlp',
-  'tensorflow',
-  'pytorch',
-  'pandas',
-  'numpy',
-  'scikit-learn',
-  'linux',
-  'unix',
-  'windows',
-  'macos',
-  'oauth',
-  'jwt',
-  'saml',
-  'sso',
-  'ldap',
-  'pmp',
-  'aws certified',
-  'azure certified',
-  'cka',
-  'ckad',
-  'cissp',
-  'data structures',
-  'algorithms',
-  'oop',
-  'solid',
-  'design patterns',
-  'tdd',
-  'bdd',
-  'unit testing',
-  'integration testing',
-  'e2e',
-  'jest',
-  'mocha',
-  'cypress',
-  'playwright',
-  'selenium',
-  'prisma',
-  'typeorm',
-  'sequelize',
-  'hibernate',
-  'storybook',
-  'responsive design',
-  'accessibility',
-  'a11y',
-  'api',
-  'sdk',
-  'cli',
-  'saas',
-  'paas',
-  'iaas',
+  'javascript', 'typescript', 'python', 'java', 'c#', 'c++', 'ruby', 'go',
+  'rust', 'swift', 'kotlin', 'php', 'scala', 'r', 'matlab', 'perl',
+  'react', 'angular', 'vue', 'svelte', 'nextjs', 'next.js', 'nuxt',
+  'node.js', 'nodejs', 'express', 'nestjs', 'django', 'flask', 'fastapi',
+  'spring', 'spring boot', '.net', 'rails', 'laravel',
+  'aws', 'azure', 'gcp', 'docker', 'kubernetes', 'k8s', 'terraform',
+  'jenkins', 'github actions', 'ci/cd', 'cicd',
+  'postgresql', 'mysql', 'mongodb', 'redis', 'elasticsearch', 'kafka',
+  'rabbitmq', 'graphql', 'rest', 'restful', 'grpc', 'microservices',
+  'sql', 'nosql', 'dynamodb', 'cassandra', 'oracle',
+  'html', 'css', 'sass', 'scss', 'tailwind', 'bootstrap', 'webpack',
+  'vite', 'babel', 'eslint', 'prettier',
+  'git', 'jira', 'confluence', 'figma', 'sketch',
+  'agile', 'scrum', 'kanban', 'devops', 'sre',
+  'machine learning', 'ml', 'ai', 'deep learning', 'nlp', 'tensorflow',
+  'pytorch', 'pandas', 'numpy', 'scikit-learn',
+  'linux', 'unix', 'windows', 'macos',
+  'oauth', 'jwt', 'saml', 'sso', 'ldap',
+  'pmp', 'aws certified', 'azure certified', 'cka', 'ckad', 'cissp',
+  'data structures', 'algorithms', 'oop', 'solid', 'design patterns',
+  'tdd', 'bdd', 'unit testing', 'integration testing', 'e2e',
+  'jest', 'mocha', 'cypress', 'playwright', 'selenium',
+  'prisma', 'typeorm', 'sequelize', 'hibernate',
+  'storybook', 'responsive design', 'accessibility', 'a11y',
+  'api', 'sdk', 'cli', 'saas', 'paas', 'iaas',
 ]);
 
 const IMPORTANCE_INDICATORS = {
-  required: [
-    'must have',
-    'required',
-    'essential',
-    'mandatory',
-    'must be',
-    'need to have',
-  ],
-  preferred: [
-    'preferred',
-    'nice to have',
-    'ideally',
-    'strongly preferred',
-    'highly desired',
-  ],
-  bonus: [
-    'bonus',
-    'plus',
-    'advantage',
-    'asset',
-    'beneficial',
-    'would be great',
-  ],
+  required: ['must have', 'required', 'essential', 'mandatory', 'must be', 'need to have'],
+  preferred: ['preferred', 'nice to have', 'ideally', 'strongly preferred', 'highly desired'],
+  bonus: ['bonus', 'plus', 'advantage', 'asset', 'beneficial', 'would be great'],
 };
 
 const IMPACT_WORDS = [
-  'achieved',
-  'improved',
-  'increased',
-  'reduced',
-  'led',
-  'managed',
-  'delivered',
-  'built',
-  'created',
-  'designed',
-  'implemented',
-  'developed',
-  'launched',
-  'optimized',
-  'streamlined',
-  'automated',
-  'mentored',
-  'spearheaded',
-  'orchestrated',
-  'transformed',
-  'scaled',
-  'drove',
-  'generated',
-  'saved',
-  'accelerated',
-  'pioneered',
-  'established',
+  'achieved', 'improved', 'increased', 'reduced', 'led', 'managed',
+  'delivered', 'built', 'created', 'designed', 'implemented', 'developed',
+  'launched', 'optimized', 'streamlined', 'automated', 'mentored',
+  'spearheaded', 'orchestrated', 'transformed', 'scaled', 'drove',
+  'generated', 'saved', 'accelerated', 'pioneered', 'established',
 ];
 
 @Injectable()
 export class AtsService {
-  private readonly logger = new Logger(AtsService.name);
-
-  constructor(
-    private readonly configService: ConfigService,
-    private readonly openAiProvider: OpenAiProvider,
-    private readonly aiUsageService: AiUsageService,
-    private readonly unleashService: UnleashService,
-    private readonly metricsService: MetricsService,
-  ) {}
-
-  async analyze(
-    dto: AtsScoreRequestDto,
-    userId: string,
-  ): Promise<AtsScoreResponseDto> {
+  analyze(dto: AtsScoreRequestDto): AtsScoreResponseDto {
     const { cvText, jobDescription, skills } = dto;
     const cvLower = cvText.toLowerCase();
     const jdLower = jobDescription.toLowerCase();
@@ -405,7 +88,7 @@ export class AtsService {
     const sectionScores = this.scoreSections(cvLower, jdLower, keywordMatches);
 
     // Calculate keyword match rate
-    const matchedCount = keywordMatches.filter(k => k.found).length;
+    const matchedCount = keywordMatches.filter((k) => k.found).length;
     const keywordMatchRate =
       keywordMatches.length > 0
         ? Math.round((matchedCount / keywordMatches.length) * 100)
@@ -433,8 +116,8 @@ export class AtsService {
 
     // Find missing keywords
     const missingKeywords = keywordMatches
-      .filter(k => !k.found)
-      .map(k => k.keyword);
+      .filter((k) => !k.found)
+      .map((k) => k.keyword);
 
     // Generate suggestions
     const suggestions = this.generateSuggestions(
@@ -444,7 +127,7 @@ export class AtsService {
       impactScore,
     );
 
-    const result: AtsScoreResponseDto = {
+    return {
       overallScore: Math.min(100, Math.max(0, overallScore)),
       keywordMatches,
       sectionScores,
@@ -452,116 +135,16 @@ export class AtsService {
       missingKeywords,
       keywordMatchRate,
     };
-
-    if (this.shouldUseLlm(userId)) {
-      const startedAt = Date.now();
-      let quotaConsumed = false;
-      try {
-        await this.aiUsageService.consumeQuota(
-          userId,
-          AiUsageFeature.ATS_SCORE,
-        );
-        quotaConsumed = true;
-        const llmSuggestions = await this.openAiProvider.generateAtsSuggestions(
-          {
-            cvText,
-            jobDescription,
-            missingKeywords: result.missingKeywords,
-            existingSuggestions: result.suggestions,
-          },
-        );
-        result.suggestions = this.mergeSuggestions(
-          result.suggestions,
-          llmSuggestions,
-        );
-        this.metricsService.recordAiCall({
-          feature: 'ats_score',
-          provider: 'openai',
-          status: 'success',
-          durationMs: Date.now() - startedAt,
-        });
-      } catch (error) {
-        this.metricsService.recordAiCall({
-          feature: 'ats_score',
-          provider: 'openai',
-          status: 'error',
-          durationMs: Date.now() - startedAt,
-        });
-
-        if (quotaConsumed) {
-          await this.refundQuotaOnProviderFailure(
-            userId,
-            AiUsageFeature.ATS_SCORE,
-          );
-        }
-
-        const message = error instanceof Error ? error.message : String(error);
-        this.logger.warn(
-          `OpenAI ATS suggestions failed; using heuristic suggestions only. ${message}`,
-        );
-      }
-    }
-
-    return result;
-  }
-
-  private async refundQuotaOnProviderFailure(
-    userId: string,
-    feature: AiUsageFeature,
-  ): Promise<void> {
-    try {
-      await this.aiUsageService.refundQuota(userId, feature);
-    } catch (refundError) {
-      const message =
-        refundError instanceof Error
-          ? refundError.message
-          : String(refundError);
-      this.logger.error(
-        `Failed to refund AI quota for feature=${feature.toLowerCase()}, userId=${userId}: ${message}`,
-      );
-    }
-  }
-
-  private shouldUseLlm(userId: string): boolean {
-    const provider = this.configService
-      .get<string>('AI_PROVIDER', 'builtin')
-      ?.trim()
-      .toLowerCase();
-    if (provider !== 'openai') {
-      return false;
-    }
-
-    if (!this.openAiProvider.isAvailable()) {
-      return false;
-    }
-
-    return this.unleashService.isEnabled(AI_LLM_ATS_FLAG, { userId });
-  }
-
-  private mergeSuggestions(
-    heuristicSuggestions: string[],
-    llmSuggestions: string[],
-  ): string[] {
-    const merged = [...heuristicSuggestions, ...llmSuggestions].map(s =>
-      s.trim(),
-    );
-    const unique = new Set<string>();
-    for (const suggestion of merged) {
-      if (!suggestion) continue;
-      unique.add(suggestion);
-      if (unique.size >= 10) break;
-    }
-    return [...unique];
   }
 
   private extractKeywords(
     jdLower: string,
     jdOriginal: string,
-  ): Array<{
-    keyword: string;
-    importance: 'required' | 'preferred' | 'bonus';
-  }> {
-    const keywords: Map<string, 'required' | 'preferred' | 'bonus'> = new Map();
+  ): Array<{ keyword: string; importance: 'required' | 'preferred' | 'bonus' }> {
+    const keywords: Map<
+      string,
+      'required' | 'preferred' | 'bonus'
+    > = new Map();
 
     // Extract multi-word technical terms first
     for (const term of TECHNICAL_TERMS) {
@@ -582,8 +165,7 @@ export class AtsService {
     }
 
     // Also extract capitalized phrases that may be product/tool names
-    const capitalizedPattern =
-      /\b([A-Z][a-zA-Z0-9]*(?:\s[A-Z][a-zA-Z0-9]*)*)\b/g;
+    const capitalizedPattern = /\b([A-Z][a-zA-Z0-9]*(?:\s[A-Z][a-zA-Z0-9]*)*)\b/g;
     let match: RegExpExecArray | null;
     while ((match = capitalizedPattern.exec(jdOriginal)) !== null) {
       const term = match[1];
@@ -626,10 +208,7 @@ export class AtsService {
     if (keywordIndex === -1) return 'bonus';
 
     const contextStart = Math.max(0, keywordIndex - 100);
-    const contextEnd = Math.min(
-      jdLower.length,
-      keywordIndex + keyword.length + 100,
-    );
+    const contextEnd = Math.min(jdLower.length, keywordIndex + keyword.length + 100);
     const context = jdLower.slice(contextStart, contextEnd);
 
     for (const indicator of IMPORTANCE_INDICATORS.required) {
@@ -648,14 +227,11 @@ export class AtsService {
   }
 
   private matchKeywords(
-    keywords: Array<{
-      keyword: string;
-      importance: 'required' | 'preferred' | 'bonus';
-    }>,
+    keywords: Array<{ keyword: string; importance: 'required' | 'preferred' | 'bonus' }>,
     cvLower: string,
     skills?: string[],
   ): KeywordMatchDto[] {
-    const skillsLower = (skills || []).map(s => s.toLowerCase());
+    const skillsLower = (skills || []).map((s) => s.toLowerCase());
 
     return keywords.map(({ keyword, importance }) => {
       // Use word boundary matching to avoid false positives (e.g. "go" matching "ongoing")
@@ -665,7 +241,7 @@ export class AtsService {
 
       // Check in skills array (exact match only)
       if (!found && skillsLower.length > 0) {
-        found = skillsLower.some(s => s === keyword);
+        found = skillsLower.some((s) => s === keyword);
       }
 
       // Handle common variations
@@ -695,17 +271,17 @@ export class AtsService {
     }
     // Common abbreviation mappings
     const abbrevMap: Record<string, string[]> = {
-      javascript: ['js'],
-      typescript: ['ts'],
-      kubernetes: ['k8s'],
-      postgresql: ['postgres', 'psql'],
+      'javascript': ['js'],
+      'typescript': ['ts'],
+      'kubernetes': ['k8s'],
+      'postgresql': ['postgres', 'psql'],
       'continuous integration': ['ci'],
       'continuous deployment': ['cd'],
       'ci/cd': ['cicd', 'ci cd'],
     };
     const variants = abbrevMap[keyword];
     if (variants) {
-      return variants.some(v => cvLower.includes(v));
+      return variants.some((v) => cvLower.includes(v));
     }
     return false;
   }
@@ -740,11 +316,7 @@ export class AtsService {
     const checks: string[] = [];
 
     // Email check: bounded quantifiers prevent polynomial backtracking
-    if (
-      /[a-z0-9]{1,64}(?:[._%+\-][a-z0-9]{1,64}){0,10}@[a-z0-9]{1,253}(?:[.\-][a-z0-9]{1,63}){0,10}\.[a-z]{2,6}/.test(
-        cvLower,
-      )
-    ) {
+    if (/[a-z0-9]{1,64}(?:[._%+\-][a-z0-9]{1,64}){0,10}@[a-z0-9]{1,253}(?:[.\-][a-z0-9]{1,63}){0,10}\.[a-z]{2,6}/.test(cvLower)) {
       score += 25;
     } else {
       checks.push('email');
@@ -790,9 +362,7 @@ export class AtsService {
     }
 
     // Has quantifiable achievements (numbers, percentages)
-    const quantifiers = cvLower.match(
-      /\d{1,10}%|\$\d{1,10}|\d{1,6} ?(?:years?|months?|clients?|users?|projects?)/g,
-    );
+    const quantifiers = cvLower.match(/\d{1,10}%|\$\d{1,10}|\d{1,6} ?(?:years?|months?|clients?|users?|projects?)/g);
     if (quantifiers && quantifiers.length >= 3) {
       score += 40;
     } else if (quantifiers && quantifiers.length >= 1) {
@@ -800,7 +370,7 @@ export class AtsService {
     }
 
     // Has action verbs / impact language
-    const impactCount = IMPACT_WORDS.filter(w => cvLower.includes(w)).length;
+    const impactCount = IMPACT_WORDS.filter((w) => cvLower.includes(w)).length;
     if (impactCount >= 5) {
       score += 30;
     } else if (impactCount >= 2) {
@@ -834,16 +404,16 @@ export class AtsService {
 
     // Keyword overlap
     const requiredMatches = keywordMatches.filter(
-      k => k.importance === 'required',
+      (k) => k.importance === 'required',
     );
-    const requiredFound = requiredMatches.filter(k => k.found).length;
+    const requiredFound = requiredMatches.filter((k) => k.found).length;
     const requiredTotal = requiredMatches.length;
 
     if (requiredTotal > 0) {
       score += Math.round((requiredFound / requiredTotal) * 80);
     } else {
       // No required keywords identified, score on overall match
-      const allFound = keywordMatches.filter(k => k.found).length;
+      const allFound = keywordMatches.filter((k) => k.found).length;
       const allTotal = keywordMatches.length;
       if (allTotal > 0) {
         score += Math.round((allFound / allTotal) * 80);
@@ -873,18 +443,8 @@ export class AtsService {
     }
 
     // Degree mentioned
-    const degrees = [
-      'bachelor',
-      'master',
-      'phd',
-      'mba',
-      'b.s.',
-      'm.s.',
-      'b.a.',
-      'm.a.',
-      'associate',
-    ];
-    if (degrees.some(d => cvLower.includes(d))) {
+    const degrees = ['bachelor', 'master', 'phd', 'mba', 'b.s.', 'm.s.', 'b.a.', 'm.a.', 'associate'];
+    if (degrees.some((d) => cvLower.includes(d))) {
       score += 30;
     }
 
@@ -926,9 +486,9 @@ export class AtsService {
     const jdWords = jdLower
       .replace(/[^a-z0-9\s]/g, ' ')
       .split(/\s+/)
-      .filter(w => w.length > 3 && !STOP_WORDS.has(w));
+      .filter((w) => w.length > 3 && !STOP_WORDS.has(w));
     const uniqueJdWords = [...new Set(jdWords)].slice(0, 20);
-    const matchCount = uniqueJdWords.filter(w =>
+    const matchCount = uniqueJdWords.filter((w) =>
       summarySection.includes(w),
     ).length;
 
@@ -958,15 +518,14 @@ export class AtsService {
     }
 
     // Has clear section separators (newlines, headings pattern)
-    const lines = cvText.split('\n').filter(l => l.trim().length > 0);
+    const lines = cvText.split('\n').filter((l) => l.trim().length > 0);
     if (lines.length >= 10) {
       score += 20;
     }
 
     // No excessive special characters (ATS-unfriendly), excluding common bullets
-    const specialChars = (
-      cvText.match(/[^\w\s.,;:!?@#$%&*()\-+/'"•▪◦\-*]/g) || []
-    ).length;
+    const specialChars = (cvText.match(/[^\w\s.,;:!?@#$%&*()\-+/'"•▪◦\-*]/g) || [])
+      .length;
     if (specialChars < cvText.length * 0.02) {
       score += 25;
     } else {
@@ -974,7 +533,9 @@ export class AtsService {
     }
 
     // Consistent bullet points or structured content
-    const bulletLines = lines.filter(l => /^\s*[-•*▪◦]\s/.test(l)).length;
+    const bulletLines = lines.filter((l) =>
+      /^\s*[-•*▪◦]\s/.test(l),
+    ).length;
     if (bulletLines >= 5) {
       score += 25;
     } else if (bulletLines >= 2) {
@@ -987,12 +548,10 @@ export class AtsService {
   }
 
   private scoreImpactLanguage(cvLower: string): number {
-    const impactCount = IMPACT_WORDS.filter(w => cvLower.includes(w)).length;
+    const impactCount = IMPACT_WORDS.filter((w) => cvLower.includes(w)).length;
 
     // Has numbers/metrics
-    const metrics = (
-      cvLower.match(/\d{1,10}%|\$[\d,]{1,15}|\d{1,10}x|\d{1,10}\+/g) || []
-    ).length;
+    const metrics = (cvLower.match(/\d{1,10}%|\$[\d,]{1,15}|\d{1,10}x|\d{1,10}\+/g) || []).length;
 
     let score = 0;
 
@@ -1015,7 +574,7 @@ export class AtsService {
 
     // Missing required keywords
     const missingRequired = keywordMatches.filter(
-      k => !k.found && k.importance === 'required',
+      (k) => !k.found && k.importance === 'required',
     );
     for (const kw of missingRequired.slice(0, 5)) {
       suggestions.push(
@@ -1025,7 +584,7 @@ export class AtsService {
 
     // Missing preferred keywords
     const missingPreferred = keywordMatches.filter(
-      k => !k.found && k.importance === 'preferred',
+      (k) => !k.found && k.importance === 'preferred',
     );
     for (const kw of missingPreferred.slice(0, 3)) {
       suggestions.push(
@@ -1036,9 +595,7 @@ export class AtsService {
     // Section-specific suggestions
     for (const section of sectionScores) {
       if (section.score < 50) {
-        suggestions.push(
-          `Improve your ${section.name} section: ${section.feedback}`,
-        );
+        suggestions.push(`Improve your ${section.name} section: ${section.feedback}`);
       }
     }
 

--- a/src/modules/ats/ats.service.ts
+++ b/src/modules/ats/ats.service.ts
@@ -7,68 +7,365 @@ import {
 } from './dto/ats-score.response.dto';
 
 const STOP_WORDS = new Set([
-  'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
-  'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
-  'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
-  'could', 'should', 'may', 'might', 'shall', 'can', 'need', 'dare',
-  'ought', 'used', 'this', 'that', 'these', 'those', 'i', 'me', 'my',
-  'myself', 'we', 'our', 'ours', 'ourselves', 'you', 'your', 'yours',
-  'yourself', 'yourselves', 'he', 'him', 'his', 'himself', 'she', 'her',
-  'hers', 'herself', 'it', 'its', 'itself', 'they', 'them', 'their',
-  'theirs', 'themselves', 'what', 'which', 'who', 'whom', 'when', 'where',
-  'why', 'how', 'all', 'each', 'every', 'both', 'few', 'more', 'most',
-  'other', 'some', 'such', 'no', 'nor', 'not', 'only', 'own', 'same',
-  'so', 'than', 'too', 'very', 'just', 'because', 'as', 'until', 'while',
-  'about', 'between', 'through', 'during', 'before', 'after', 'above',
-  'below', 'up', 'down', 'out', 'off', 'over', 'under', 'again', 'further',
-  'then', 'once', 'here', 'there', 'any', 'if', 'also', 'etc', 'per',
-  'able', 'must', 'well', 'including', 'within', 'using', 'work', 'working',
-  'experience', 'years', 'year', 'team', 'role', 'job', 'company',
-  'requirements', 'required', 'preferred', 'responsibilities', 'looking',
-  'join', 'strong', 'knowledge', 'understanding', 'minimum', 'plus',
-  'ideal', 'candidate', 'position', 'opportunity', 'based',
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'but',
+  'in',
+  'on',
+  'at',
+  'to',
+  'for',
+  'of',
+  'with',
+  'by',
+  'from',
+  'is',
+  'are',
+  'was',
+  'were',
+  'be',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'do',
+  'does',
+  'did',
+  'will',
+  'would',
+  'could',
+  'should',
+  'may',
+  'might',
+  'shall',
+  'can',
+  'need',
+  'dare',
+  'ought',
+  'used',
+  'this',
+  'that',
+  'these',
+  'those',
+  'i',
+  'me',
+  'my',
+  'myself',
+  'we',
+  'our',
+  'ours',
+  'ourselves',
+  'you',
+  'your',
+  'yours',
+  'yourself',
+  'yourselves',
+  'he',
+  'him',
+  'his',
+  'himself',
+  'she',
+  'her',
+  'hers',
+  'herself',
+  'it',
+  'its',
+  'itself',
+  'they',
+  'them',
+  'their',
+  'theirs',
+  'themselves',
+  'what',
+  'which',
+  'who',
+  'whom',
+  'when',
+  'where',
+  'why',
+  'how',
+  'all',
+  'each',
+  'every',
+  'both',
+  'few',
+  'more',
+  'most',
+  'other',
+  'some',
+  'such',
+  'no',
+  'nor',
+  'not',
+  'only',
+  'own',
+  'same',
+  'so',
+  'than',
+  'too',
+  'very',
+  'just',
+  'because',
+  'as',
+  'until',
+  'while',
+  'about',
+  'between',
+  'through',
+  'during',
+  'before',
+  'after',
+  'above',
+  'below',
+  'up',
+  'down',
+  'out',
+  'off',
+  'over',
+  'under',
+  'again',
+  'further',
+  'then',
+  'once',
+  'here',
+  'there',
+  'any',
+  'if',
+  'also',
+  'etc',
+  'per',
+  'able',
+  'must',
+  'well',
+  'including',
+  'within',
+  'using',
+  'work',
+  'working',
+  'experience',
+  'years',
+  'year',
+  'team',
+  'role',
+  'job',
+  'company',
+  'requirements',
+  'required',
+  'preferred',
+  'responsibilities',
+  'looking',
+  'join',
+  'strong',
+  'knowledge',
+  'understanding',
+  'minimum',
+  'plus',
+  'ideal',
+  'candidate',
+  'position',
+  'opportunity',
+  'based',
 ]);
 
 const TECHNICAL_TERMS = new Set([
-  'javascript', 'typescript', 'python', 'java', 'c#', 'c++', 'ruby', 'go',
-  'rust', 'swift', 'kotlin', 'php', 'scala', 'r', 'matlab', 'perl',
-  'react', 'angular', 'vue', 'svelte', 'nextjs', 'next.js', 'nuxt',
-  'node.js', 'nodejs', 'express', 'nestjs', 'django', 'flask', 'fastapi',
-  'spring', 'spring boot', '.net', 'rails', 'laravel',
-  'aws', 'azure', 'gcp', 'docker', 'kubernetes', 'k8s', 'terraform',
-  'jenkins', 'github actions', 'ci/cd', 'cicd',
-  'postgresql', 'mysql', 'mongodb', 'redis', 'elasticsearch', 'kafka',
-  'rabbitmq', 'graphql', 'rest', 'restful', 'grpc', 'microservices',
-  'sql', 'nosql', 'dynamodb', 'cassandra', 'oracle',
-  'html', 'css', 'sass', 'scss', 'tailwind', 'bootstrap', 'webpack',
-  'vite', 'babel', 'eslint', 'prettier',
-  'git', 'jira', 'confluence', 'figma', 'sketch',
-  'agile', 'scrum', 'kanban', 'devops', 'sre',
-  'machine learning', 'ml', 'ai', 'deep learning', 'nlp', 'tensorflow',
-  'pytorch', 'pandas', 'numpy', 'scikit-learn',
-  'linux', 'unix', 'windows', 'macos',
-  'oauth', 'jwt', 'saml', 'sso', 'ldap',
-  'pmp', 'aws certified', 'azure certified', 'cka', 'ckad', 'cissp',
-  'data structures', 'algorithms', 'oop', 'solid', 'design patterns',
-  'tdd', 'bdd', 'unit testing', 'integration testing', 'e2e',
-  'jest', 'mocha', 'cypress', 'playwright', 'selenium',
-  'prisma', 'typeorm', 'sequelize', 'hibernate',
-  'storybook', 'responsive design', 'accessibility', 'a11y',
-  'api', 'sdk', 'cli', 'saas', 'paas', 'iaas',
+  'javascript',
+  'typescript',
+  'python',
+  'java',
+  'c#',
+  'c++',
+  'ruby',
+  'go',
+  'rust',
+  'swift',
+  'kotlin',
+  'php',
+  'scala',
+  'r',
+  'matlab',
+  'perl',
+  'react',
+  'angular',
+  'vue',
+  'svelte',
+  'nextjs',
+  'next.js',
+  'nuxt',
+  'node.js',
+  'nodejs',
+  'express',
+  'nestjs',
+  'django',
+  'flask',
+  'fastapi',
+  'spring',
+  'spring boot',
+  '.net',
+  'rails',
+  'laravel',
+  'aws',
+  'azure',
+  'gcp',
+  'docker',
+  'kubernetes',
+  'k8s',
+  'terraform',
+  'jenkins',
+  'github actions',
+  'ci/cd',
+  'cicd',
+  'postgresql',
+  'mysql',
+  'mongodb',
+  'redis',
+  'elasticsearch',
+  'kafka',
+  'rabbitmq',
+  'graphql',
+  'rest',
+  'restful',
+  'grpc',
+  'microservices',
+  'sql',
+  'nosql',
+  'dynamodb',
+  'cassandra',
+  'oracle',
+  'html',
+  'css',
+  'sass',
+  'scss',
+  'tailwind',
+  'bootstrap',
+  'webpack',
+  'vite',
+  'babel',
+  'eslint',
+  'prettier',
+  'git',
+  'jira',
+  'confluence',
+  'figma',
+  'sketch',
+  'agile',
+  'scrum',
+  'kanban',
+  'devops',
+  'sre',
+  'machine learning',
+  'ml',
+  'ai',
+  'deep learning',
+  'nlp',
+  'tensorflow',
+  'pytorch',
+  'pandas',
+  'numpy',
+  'scikit-learn',
+  'linux',
+  'unix',
+  'windows',
+  'macos',
+  'oauth',
+  'jwt',
+  'saml',
+  'sso',
+  'ldap',
+  'pmp',
+  'aws certified',
+  'azure certified',
+  'cka',
+  'ckad',
+  'cissp',
+  'data structures',
+  'algorithms',
+  'oop',
+  'solid',
+  'design patterns',
+  'tdd',
+  'bdd',
+  'unit testing',
+  'integration testing',
+  'e2e',
+  'jest',
+  'mocha',
+  'cypress',
+  'playwright',
+  'selenium',
+  'prisma',
+  'typeorm',
+  'sequelize',
+  'hibernate',
+  'storybook',
+  'responsive design',
+  'accessibility',
+  'a11y',
+  'api',
+  'sdk',
+  'cli',
+  'saas',
+  'paas',
+  'iaas',
 ]);
 
 const IMPORTANCE_INDICATORS = {
-  required: ['must have', 'required', 'essential', 'mandatory', 'must be', 'need to have'],
-  preferred: ['preferred', 'nice to have', 'ideally', 'strongly preferred', 'highly desired'],
-  bonus: ['bonus', 'plus', 'advantage', 'asset', 'beneficial', 'would be great'],
+  required: [
+    'must have',
+    'required',
+    'essential',
+    'mandatory',
+    'must be',
+    'need to have',
+  ],
+  preferred: [
+    'preferred',
+    'nice to have',
+    'ideally',
+    'strongly preferred',
+    'highly desired',
+  ],
+  bonus: [
+    'bonus',
+    'plus',
+    'advantage',
+    'asset',
+    'beneficial',
+    'would be great',
+  ],
 };
 
 const IMPACT_WORDS = [
-  'achieved', 'improved', 'increased', 'reduced', 'led', 'managed',
-  'delivered', 'built', 'created', 'designed', 'implemented', 'developed',
-  'launched', 'optimized', 'streamlined', 'automated', 'mentored',
-  'spearheaded', 'orchestrated', 'transformed', 'scaled', 'drove',
-  'generated', 'saved', 'accelerated', 'pioneered', 'established',
+  'achieved',
+  'improved',
+  'increased',
+  'reduced',
+  'led',
+  'managed',
+  'delivered',
+  'built',
+  'created',
+  'designed',
+  'implemented',
+  'developed',
+  'launched',
+  'optimized',
+  'streamlined',
+  'automated',
+  'mentored',
+  'spearheaded',
+  'orchestrated',
+  'transformed',
+  'scaled',
+  'drove',
+  'generated',
+  'saved',
+  'accelerated',
+  'pioneered',
+  'established',
 ];
 
 @Injectable()
@@ -88,7 +385,7 @@ export class AtsService {
     const sectionScores = this.scoreSections(cvLower, jdLower, keywordMatches);
 
     // Calculate keyword match rate
-    const matchedCount = keywordMatches.filter((k) => k.found).length;
+    const matchedCount = keywordMatches.filter(k => k.found).length;
     const keywordMatchRate =
       keywordMatches.length > 0
         ? Math.round((matchedCount / keywordMatches.length) * 100)
@@ -116,8 +413,8 @@ export class AtsService {
 
     // Find missing keywords
     const missingKeywords = keywordMatches
-      .filter((k) => !k.found)
-      .map((k) => k.keyword);
+      .filter(k => !k.found)
+      .map(k => k.keyword);
 
     // Generate suggestions
     const suggestions = this.generateSuggestions(
@@ -140,11 +437,11 @@ export class AtsService {
   private extractKeywords(
     jdLower: string,
     jdOriginal: string,
-  ): Array<{ keyword: string; importance: 'required' | 'preferred' | 'bonus' }> {
-    const keywords: Map<
-      string,
-      'required' | 'preferred' | 'bonus'
-    > = new Map();
+  ): Array<{
+    keyword: string;
+    importance: 'required' | 'preferred' | 'bonus';
+  }> {
+    const keywords: Map<string, 'required' | 'preferred' | 'bonus'> = new Map();
 
     // Extract multi-word technical terms first
     for (const term of TECHNICAL_TERMS) {
@@ -165,7 +462,8 @@ export class AtsService {
     }
 
     // Also extract capitalized phrases that may be product/tool names
-    const capitalizedPattern = /\b([A-Z][a-zA-Z0-9]*(?:\s[A-Z][a-zA-Z0-9]*)*)\b/g;
+    const capitalizedPattern =
+      /\b([A-Z][a-zA-Z0-9]*(?:\s[A-Z][a-zA-Z0-9]*)*)\b/g;
     let match: RegExpExecArray | null;
     while ((match = capitalizedPattern.exec(jdOriginal)) !== null) {
       const term = match[1];
@@ -208,7 +506,10 @@ export class AtsService {
     if (keywordIndex === -1) return 'bonus';
 
     const contextStart = Math.max(0, keywordIndex - 100);
-    const contextEnd = Math.min(jdLower.length, keywordIndex + keyword.length + 100);
+    const contextEnd = Math.min(
+      jdLower.length,
+      keywordIndex + keyword.length + 100,
+    );
     const context = jdLower.slice(contextStart, contextEnd);
 
     for (const indicator of IMPORTANCE_INDICATORS.required) {
@@ -227,11 +528,14 @@ export class AtsService {
   }
 
   private matchKeywords(
-    keywords: Array<{ keyword: string; importance: 'required' | 'preferred' | 'bonus' }>,
+    keywords: Array<{
+      keyword: string;
+      importance: 'required' | 'preferred' | 'bonus';
+    }>,
     cvLower: string,
     skills?: string[],
   ): KeywordMatchDto[] {
-    const skillsLower = (skills || []).map((s) => s.toLowerCase());
+    const skillsLower = (skills || []).map(s => s.toLowerCase());
 
     return keywords.map(({ keyword, importance }) => {
       // Use word boundary matching to avoid false positives (e.g. "go" matching "ongoing")
@@ -241,7 +545,7 @@ export class AtsService {
 
       // Check in skills array (exact match only)
       if (!found && skillsLower.length > 0) {
-        found = skillsLower.some((s) => s === keyword);
+        found = skillsLower.some(s => s === keyword);
       }
 
       // Handle common variations
@@ -271,17 +575,17 @@ export class AtsService {
     }
     // Common abbreviation mappings
     const abbrevMap: Record<string, string[]> = {
-      'javascript': ['js'],
-      'typescript': ['ts'],
-      'kubernetes': ['k8s'],
-      'postgresql': ['postgres', 'psql'],
+      javascript: ['js'],
+      typescript: ['ts'],
+      kubernetes: ['k8s'],
+      postgresql: ['postgres', 'psql'],
       'continuous integration': ['ci'],
       'continuous deployment': ['cd'],
       'ci/cd': ['cicd', 'ci cd'],
     };
     const variants = abbrevMap[keyword];
     if (variants) {
-      return variants.some((v) => cvLower.includes(v));
+      return variants.some(v => cvLower.includes(v));
     }
     return false;
   }
@@ -316,7 +620,11 @@ export class AtsService {
     const checks: string[] = [];
 
     // Email check: bounded quantifiers prevent polynomial backtracking
-    if (/[a-z0-9]{1,64}(?:[._%+\-][a-z0-9]{1,64}){0,10}@[a-z0-9]{1,253}(?:[.\-][a-z0-9]{1,63}){0,10}\.[a-z]{2,6}/.test(cvLower)) {
+    if (
+      /[a-z0-9]{1,64}(?:[._%+\-][a-z0-9]{1,64}){0,10}@[a-z0-9]{1,253}(?:[.\-][a-z0-9]{1,63}){0,10}\.[a-z]{2,6}/.test(
+        cvLower,
+      )
+    ) {
       score += 25;
     } else {
       checks.push('email');
@@ -362,7 +670,9 @@ export class AtsService {
     }
 
     // Has quantifiable achievements (numbers, percentages)
-    const quantifiers = cvLower.match(/\d{1,10}%|\$\d{1,10}|\d{1,6} ?(?:years?|months?|clients?|users?|projects?)/g);
+    const quantifiers = cvLower.match(
+      /\d{1,10}%|\$\d{1,10}|\d{1,6} ?(?:years?|months?|clients?|users?|projects?)/g,
+    );
     if (quantifiers && quantifiers.length >= 3) {
       score += 40;
     } else if (quantifiers && quantifiers.length >= 1) {
@@ -370,7 +680,7 @@ export class AtsService {
     }
 
     // Has action verbs / impact language
-    const impactCount = IMPACT_WORDS.filter((w) => cvLower.includes(w)).length;
+    const impactCount = IMPACT_WORDS.filter(w => cvLower.includes(w)).length;
     if (impactCount >= 5) {
       score += 30;
     } else if (impactCount >= 2) {
@@ -404,16 +714,16 @@ export class AtsService {
 
     // Keyword overlap
     const requiredMatches = keywordMatches.filter(
-      (k) => k.importance === 'required',
+      k => k.importance === 'required',
     );
-    const requiredFound = requiredMatches.filter((k) => k.found).length;
+    const requiredFound = requiredMatches.filter(k => k.found).length;
     const requiredTotal = requiredMatches.length;
 
     if (requiredTotal > 0) {
       score += Math.round((requiredFound / requiredTotal) * 80);
     } else {
       // No required keywords identified, score on overall match
-      const allFound = keywordMatches.filter((k) => k.found).length;
+      const allFound = keywordMatches.filter(k => k.found).length;
       const allTotal = keywordMatches.length;
       if (allTotal > 0) {
         score += Math.round((allFound / allTotal) * 80);
@@ -443,8 +753,18 @@ export class AtsService {
     }
 
     // Degree mentioned
-    const degrees = ['bachelor', 'master', 'phd', 'mba', 'b.s.', 'm.s.', 'b.a.', 'm.a.', 'associate'];
-    if (degrees.some((d) => cvLower.includes(d))) {
+    const degrees = [
+      'bachelor',
+      'master',
+      'phd',
+      'mba',
+      'b.s.',
+      'm.s.',
+      'b.a.',
+      'm.a.',
+      'associate',
+    ];
+    if (degrees.some(d => cvLower.includes(d))) {
       score += 30;
     }
 
@@ -486,9 +806,9 @@ export class AtsService {
     const jdWords = jdLower
       .replace(/[^a-z0-9\s]/g, ' ')
       .split(/\s+/)
-      .filter((w) => w.length > 3 && !STOP_WORDS.has(w));
+      .filter(w => w.length > 3 && !STOP_WORDS.has(w));
     const uniqueJdWords = [...new Set(jdWords)].slice(0, 20);
-    const matchCount = uniqueJdWords.filter((w) =>
+    const matchCount = uniqueJdWords.filter(w =>
       summarySection.includes(w),
     ).length;
 
@@ -518,14 +838,15 @@ export class AtsService {
     }
 
     // Has clear section separators (newlines, headings pattern)
-    const lines = cvText.split('\n').filter((l) => l.trim().length > 0);
+    const lines = cvText.split('\n').filter(l => l.trim().length > 0);
     if (lines.length >= 10) {
       score += 20;
     }
 
     // No excessive special characters (ATS-unfriendly), excluding common bullets
-    const specialChars = (cvText.match(/[^\w\s.,;:!?@#$%&*()\-+/'"•▪◦\-*]/g) || [])
-      .length;
+    const specialChars = (
+      cvText.match(/[^\w\s.,;:!?@#$%&*()\-+/'"•▪◦\-*]/g) || []
+    ).length;
     if (specialChars < cvText.length * 0.02) {
       score += 25;
     } else {
@@ -533,9 +854,7 @@ export class AtsService {
     }
 
     // Consistent bullet points or structured content
-    const bulletLines = lines.filter((l) =>
-      /^\s*[-•*▪◦]\s/.test(l),
-    ).length;
+    const bulletLines = lines.filter(l => /^\s*[-•*▪◦]\s/.test(l)).length;
     if (bulletLines >= 5) {
       score += 25;
     } else if (bulletLines >= 2) {
@@ -548,10 +867,12 @@ export class AtsService {
   }
 
   private scoreImpactLanguage(cvLower: string): number {
-    const impactCount = IMPACT_WORDS.filter((w) => cvLower.includes(w)).length;
+    const impactCount = IMPACT_WORDS.filter(w => cvLower.includes(w)).length;
 
     // Has numbers/metrics
-    const metrics = (cvLower.match(/\d{1,10}%|\$[\d,]{1,15}|\d{1,10}x|\d{1,10}\+/g) || []).length;
+    const metrics = (
+      cvLower.match(/\d{1,10}%|\$[\d,]{1,15}|\d{1,10}x|\d{1,10}\+/g) || []
+    ).length;
 
     let score = 0;
 
@@ -574,7 +895,7 @@ export class AtsService {
 
     // Missing required keywords
     const missingRequired = keywordMatches.filter(
-      (k) => !k.found && k.importance === 'required',
+      k => !k.found && k.importance === 'required',
     );
     for (const kw of missingRequired.slice(0, 5)) {
       suggestions.push(
@@ -584,7 +905,7 @@ export class AtsService {
 
     // Missing preferred keywords
     const missingPreferred = keywordMatches.filter(
-      (k) => !k.found && k.importance === 'preferred',
+      k => !k.found && k.importance === 'preferred',
     );
     for (const kw of missingPreferred.slice(0, 3)) {
       suggestions.push(
@@ -595,7 +916,9 @@ export class AtsService {
     // Section-specific suggestions
     for (const section of sectionScores) {
       if (section.score < 50) {
-        suggestions.push(`Improve your ${section.name} section: ${section.feedback}`);
+        suggestions.push(
+          `Improve your ${section.name} section: ${section.feedback}`,
+        );
       }
     }
 

--- a/src/modules/cover-letters/cover-letters.controller.ts
+++ b/src/modules/cover-letters/cover-letters.controller.ts
@@ -19,14 +19,10 @@ import {
   ApiBearerAuth,
   ApiParam,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
-import { UserPlan } from '@prisma/client';
 import { JwtUserAuthGuard } from '@/modules/auth/guards/jwt-user-auth.guard';
 import { GetUser } from '@/common/decorators/get-user.decorator';
 import { Public } from '@/common/decorators/public.decorator';
 import { User } from '@/modules/auth/entities/user.entity';
-import { RequiresPlan } from '@/modules/billing/decorators/requires-plan.decorator';
-import { RequiresPlanGuard } from '@/modules/billing/requires-plan.guard';
 import { PaginationQueryDto } from '@/shared/dto/pagination-query.dto';
 import { CoverLettersService } from './cover-letters.service';
 import {
@@ -72,7 +68,10 @@ export class CoverLettersController {
   @ApiParam({ name: 'id', description: 'Cover letter UUID' })
   @ApiResponse({ status: 200, type: CoverLetterResponseDto })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async findOne(@GetUser() user: User, @Param('id', ParseUUIDPipe) id: string) {
+  async findOne(
+    @GetUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
     return this.coverLettersService.findOne(id, user.id);
   }
 
@@ -95,17 +94,14 @@ export class CoverLettersController {
   @ApiParam({ name: 'id', description: 'Cover letter UUID' })
   @ApiResponse({ status: 204 })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async delete(@GetUser() user: User, @Param('id', ParseUUIDPipe) id: string) {
+  async delete(
+    @GetUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
     return this.coverLettersService.delete(id, user.id);
   }
 
   @Post('generate')
-  @UseGuards(RequiresPlanGuard)
-  @RequiresPlan({
-    plans: [UserPlan.PRO, UserPlan.TEAM],
-    feature: 'cover_letter_generate',
-  })
-  @Throttle({ default: { limit: 6, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Generate a cover letter from CV content',

--- a/src/modules/cover-letters/cover-letters.controller.ts
+++ b/src/modules/cover-letters/cover-letters.controller.ts
@@ -68,10 +68,7 @@ export class CoverLettersController {
   @ApiParam({ name: 'id', description: 'Cover letter UUID' })
   @ApiResponse({ status: 200, type: CoverLetterResponseDto })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async findOne(
-    @GetUser() user: User,
-    @Param('id', ParseUUIDPipe) id: string,
-  ) {
+  async findOne(@GetUser() user: User, @Param('id', ParseUUIDPipe) id: string) {
     return this.coverLettersService.findOne(id, user.id);
   }
 
@@ -94,10 +91,7 @@ export class CoverLettersController {
   @ApiParam({ name: 'id', description: 'Cover letter UUID' })
   @ApiResponse({ status: 204 })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async delete(
-    @GetUser() user: User,
-    @Param('id', ParseUUIDPipe) id: string,
-  ) {
+  async delete(@GetUser() user: User, @Param('id', ParseUUIDPipe) id: string) {
     return this.coverLettersService.delete(id, user.id);
   }
 

--- a/src/modules/cover-letters/cover-letters.service.ts
+++ b/src/modules/cover-letters/cover-letters.service.ts
@@ -4,7 +4,6 @@ import {
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '@/config/prisma.service';
 import { generateUuidv7 } from '@/shared/utils/uuid.util';
 import { PaginationQueryDto } from '@/shared/dto/pagination-query.dto';
@@ -15,27 +14,8 @@ import {
   GenerateCoverLetterRequestDto,
 } from './dto/request/cover-letter.request.dto';
 import { CvService } from '@/modules/cv/cv.service';
-import { AiUsageService } from '@/modules/ai/ai-usage.service';
-import { OpenAiProvider } from '@/modules/ai/providers/openai.provider';
-import { UnleashService } from '@/modules/unleash/unleash.service';
-import { AI_LLM_COVER_LETTER_FLAG } from '@/modules/ai/ai-feature-flags';
-import { AiUsageFeature, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { CV_INCLUDE_ALL } from '@/modules/cv/cv.constants';
-import { MetricsService } from '@/modules/metrics/metrics.service';
-
-type CoverLetterTemplate =
-  | 'classic_professional'
-  | 'impact_story'
-  | 'concise_modern';
-
-const DEFAULT_COVER_LETTER_TEMPLATE: CoverLetterTemplate =
-  'classic_professional';
-
-const COVER_LETTER_TEMPLATE_LABELS: Record<CoverLetterTemplate, string> = {
-  classic_professional: 'Classic Professional',
-  impact_story: 'Impact Story',
-  concise_modern: 'Concise Modern',
-};
 
 @Injectable()
 export class CoverLettersService {
@@ -44,11 +24,6 @@ export class CoverLettersService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly cvService: CvService,
-    private readonly configService: ConfigService,
-    private readonly openAiProvider: OpenAiProvider,
-    private readonly aiUsageService: AiUsageService,
-    private readonly unleashService: UnleashService,
-    private readonly metricsService: MetricsService,
   ) {}
 
   private async findOrThrow(id: string, userId: string) {
@@ -142,105 +117,16 @@ export class CoverLettersService {
   async generate(userId: string, dto: GenerateCoverLetterRequestDto) {
     // Fetch CV content to base the cover letter on
     const cv = await this.cvService.findOne(dto.cvId, userId);
-    const template = this.normalizeTemplate(dto.template);
 
+    const content = this.buildCoverLetter(cv, dto);
     const highlights = this.extractHighlights(cv, dto);
-    if (this.shouldUseLlm(userId)) {
-      const startedAt = Date.now();
-      let quotaConsumed = false;
-      try {
-        await this.aiUsageService.consumeQuota(
-          userId,
-          AiUsageFeature.COVER_LETTER_GENERATE,
-        );
-        quotaConsumed = true;
-        const content = await this.openAiProvider.generateCoverLetter({
-          fullName: cv.personalInfo?.fullName ?? undefined,
-          summary: cv.personalInfo?.summary ?? undefined,
-          topExperience: (cv.experiences ?? [])
-            .slice(0, 3)
-            .map(
-              exp =>
-                `${exp.title} at ${exp.company}${exp.description ? `: ${exp.description.slice(0, 180)}` : ''}`,
-            ),
-          topSkills: (cv.skills ?? []).map(skill => skill.name).slice(0, 10),
-          jobTitle: dto.jobTitle,
-          company: dto.company,
-          tone: dto.tone,
-          jobDescription: dto.jobDescription,
-          template,
-        });
-        this.metricsService.recordAiCall({
-          feature: 'cover_letter_generate',
-          provider: 'openai',
-          status: 'success',
-          durationMs: Date.now() - startedAt,
-        });
-        return { content, highlights };
-      } catch (error) {
-        this.metricsService.recordAiCall({
-          feature: 'cover_letter_generate',
-          provider: 'openai',
-          status: 'error',
-          durationMs: Date.now() - startedAt,
-        });
-
-        if (quotaConsumed) {
-          await this.refundQuotaOnProviderFailure(
-            userId,
-            AiUsageFeature.COVER_LETTER_GENERATE,
-          );
-        }
-
-        const message = error instanceof Error ? error.message : String(error);
-        this.logger.warn(
-          `OpenAI cover letter generation failed; falling back to template builder. ${message}`,
-        );
-      }
-    }
-
-    const content = this.buildCoverLetter(cv, dto, template);
 
     return { content, highlights };
-  }
-
-  private async refundQuotaOnProviderFailure(
-    userId: string,
-    feature: AiUsageFeature,
-  ): Promise<void> {
-    try {
-      await this.aiUsageService.refundQuota(userId, feature);
-    } catch (refundError) {
-      const message =
-        refundError instanceof Error
-          ? refundError.message
-          : String(refundError);
-      this.logger.error(
-        `Failed to refund AI quota for feature=${feature.toLowerCase()}, userId=${userId}: ${message}`,
-      );
-    }
-  }
-
-  private shouldUseLlm(userId: string): boolean {
-    const provider = this.configService
-      .get<string>('AI_PROVIDER', 'builtin')
-      ?.trim()
-      .toLowerCase();
-    if (provider !== 'openai') {
-      return false;
-    }
-
-    if (!this.openAiProvider.isAvailable()) {
-      return false;
-    }
-
-    return this.unleashService.isEnabled(AI_LLM_COVER_LETTER_FLAG, { userId });
   }
 
   private buildCoverLetter(
     cv: Prisma.CvGetPayload<{ include: typeof CV_INCLUDE_ALL }>,
     dto: GenerateCoverLetterRequestDto,
-    template: CoverLetterTemplate,
   ): string {
     const name = cv.personalInfo?.fullName ?? 'there';
     const company = dto.company ?? 'your company';
@@ -251,7 +137,7 @@ export class CoverLettersService {
     const experiences = cv.experiences ?? [];
     const totalYears = this.computeTotalYears(experiences);
     const topRole = experiences[0];
-    const skills = (cv.skills ?? []).map(s => s.name);
+    const skills = (cv.skills ?? []).map((s) => s.name);
     const topSkills = skills.slice(0, 5).join(', ');
 
     const greeting = this.getGreeting(tone);
@@ -259,54 +145,37 @@ export class CoverLettersService {
 
     const paragraphs: string[] = [];
 
-    if (template === 'impact_story' && topRole?.description) {
-      paragraphs.push(
-        `${topRole.description.slice(0, 220)}. This result reflects the impact I aim to bring to ${company} as ${jobTitle}.`,
-      );
-    } else {
-      // Opening paragraph
-      paragraphs.push(
-        `I am writing to express my interest in ${jobTitle} at ${company}. ` +
-          (totalYears > 0
-            ? `With ${totalYears}+ years of professional experience${topSkills ? ` and expertise in ${topSkills}` : ''}, `
-            : topSkills
-              ? `With expertise in ${topSkills}, `
-              : '') +
-          `I am confident in my ability to contribute meaningfully to your team.`,
-      );
-    }
+    // Opening paragraph
+    paragraphs.push(
+      `I am writing to express my interest in ${jobTitle} at ${company}. ` +
+        (totalYears > 0
+          ? `With ${totalYears}+ years of professional experience${topSkills ? ` and expertise in ${topSkills}` : ''}, `
+          : (topSkills ? `With expertise in ${topSkills}, ` : '')) +
+        `I am confident in my ability to contribute meaningfully to your team.`,
+    );
 
+    // Experience paragraph
     if (topRole) {
-      const experienceSentence =
-        topRole.description?.slice(0, 200) ??
-        'I have developed strong skills and delivered impactful results';
-      if (template === 'concise_modern') {
-        paragraphs.push(
-          `${topRole.title} at ${topRole.company}: ${experienceSentence}.`,
-        );
-      } else {
-        paragraphs.push(
-          `In my most recent role as ${topRole.title} at ${topRole.company}, ${experienceSentence}. ` +
-            `This experience has prepared me well for the challenges and opportunities at ${company}.`,
-        );
-      }
+      paragraphs.push(
+        `In my most recent role as ${topRole.title} at ${topRole.company}, ` +
+          `${topRole.description ? topRole.description.slice(0, 200) : 'I have developed strong skills and delivered impactful results'}. ` +
+          `This experience has prepared me well for the challenges and opportunities at ${company}.`,
+      );
     }
 
+    // Skills paragraph
     if (skills.length > 0) {
-      const skillLine = `My technical toolkit includes ${skills.slice(0, 8).join(', ')}${skills.length > 8 ? ', among others' : ''}.`;
-      if (template === 'concise_modern') {
-        paragraphs.push(skillLine);
-      } else {
-        paragraphs.push(
-          `${skillLine} I continuously invest in expanding my skill set to stay current with industry trends.`,
-        );
-      }
+      paragraphs.push(
+        `My technical toolkit includes ${skills.slice(0, 8).join(', ')}${skills.length > 8 ? ', among others' : ''}. ` +
+          `I continuously invest in expanding my skill set to stay current with industry trends.`,
+      );
     }
 
+    // Job description tailoring paragraph
     if (dto.jobDescription) {
       const keywords = this.extractJobKeywords(dto.jobDescription);
       const matchedSkills = skills.filter((s: string) =>
-        keywords.some(k => s.toLowerCase().includes(k)),
+        keywords.some((k) => s.toLowerCase().includes(k)),
       );
       if (matchedSkills.length > 0) {
         paragraphs.push(
@@ -369,7 +238,7 @@ export class CoverLettersService {
       .toLowerCase()
       .replace(/[^a-z0-9\s]/g, ' ')
       .split(/\s+/)
-      .filter(w => w.length > 3);
+      .filter((w) => w.length > 3);
     return [...new Set(words)];
   }
 
@@ -378,7 +247,6 @@ export class CoverLettersService {
     dto: GenerateCoverLetterRequestDto,
   ): string[] {
     const highlights: string[] = [];
-    const template = this.normalizeTemplate(dto.template);
 
     const experiences = cv.experiences ?? [];
     if (experiences.length > 0) {
@@ -388,7 +256,7 @@ export class CoverLettersService {
       );
     }
 
-    const skills = (cv.skills ?? []).map(s => s.name);
+    const skills = (cv.skills ?? []).map((s) => s.name);
     if (skills.length > 0) {
       highlights.push(`Key skills: ${skills.slice(0, 4).join(', ')}`);
     }
@@ -397,25 +265,11 @@ export class CoverLettersService {
       highlights.push(`Tailored for ${dto.company}`);
     }
 
-    highlights.push(`Template: ${COVER_LETTER_TEMPLATE_LABELS[template]}`);
-
     const certs = cv.certifications ?? [];
     if (certs.length > 0) {
       highlights.push(`${certs.length} certification(s)`);
     }
 
     return highlights;
-  }
-
-  private normalizeTemplate(input?: string): CoverLetterTemplate {
-    if (!input) {
-      return DEFAULT_COVER_LETTER_TEMPLATE;
-    }
-
-    if (input in COVER_LETTER_TEMPLATE_LABELS) {
-      return input as CoverLetterTemplate;
-    }
-
-    return DEFAULT_COVER_LETTER_TEMPLATE;
   }
 }

--- a/src/modules/cover-letters/cover-letters.service.ts
+++ b/src/modules/cover-letters/cover-letters.service.ts
@@ -137,7 +137,7 @@ export class CoverLettersService {
     const experiences = cv.experiences ?? [];
     const totalYears = this.computeTotalYears(experiences);
     const topRole = experiences[0];
-    const skills = (cv.skills ?? []).map((s) => s.name);
+    const skills = (cv.skills ?? []).map(s => s.name);
     const topSkills = skills.slice(0, 5).join(', ');
 
     const greeting = this.getGreeting(tone);
@@ -150,7 +150,9 @@ export class CoverLettersService {
       `I am writing to express my interest in ${jobTitle} at ${company}. ` +
         (totalYears > 0
           ? `With ${totalYears}+ years of professional experience${topSkills ? ` and expertise in ${topSkills}` : ''}, `
-          : (topSkills ? `With expertise in ${topSkills}, ` : '')) +
+          : topSkills
+            ? `With expertise in ${topSkills}, `
+            : '') +
         `I am confident in my ability to contribute meaningfully to your team.`,
     );
 
@@ -175,7 +177,7 @@ export class CoverLettersService {
     if (dto.jobDescription) {
       const keywords = this.extractJobKeywords(dto.jobDescription);
       const matchedSkills = skills.filter((s: string) =>
-        keywords.some((k) => s.toLowerCase().includes(k)),
+        keywords.some(k => s.toLowerCase().includes(k)),
       );
       if (matchedSkills.length > 0) {
         paragraphs.push(
@@ -238,7 +240,7 @@ export class CoverLettersService {
       .toLowerCase()
       .replace(/[^a-z0-9\s]/g, ' ')
       .split(/\s+/)
-      .filter((w) => w.length > 3);
+      .filter(w => w.length > 3);
     return [...new Set(words)];
   }
 
@@ -256,7 +258,7 @@ export class CoverLettersService {
       );
     }
 
-    const skills = (cv.skills ?? []).map((s) => s.name);
+    const skills = (cv.skills ?? []).map(s => s.name);
     if (skills.length > 0) {
       highlights.push(`Key skills: ${skills.slice(0, 4).join(', ')}`);
     }

--- a/src/modules/grammar/grammar.controller.ts
+++ b/src/modules/grammar/grammar.controller.ts
@@ -1,25 +1,7 @@
-import {
-  Controller,
-  Post,
-  Body,
-  HttpCode,
-  HttpStatus,
-  UseGuards,
-} from '@nestjs/common';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
-  ApiBearerAuth,
-} from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
-import { UserPlan } from '@prisma/client';
+import { Controller, Post, Body, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtUserAuthGuard } from '@/modules/auth/guards/jwt-user-auth.guard';
 import { Public } from '@/common/decorators/public.decorator';
-import { GetUser } from '@/common/decorators/get-user.decorator';
-import { User } from '@/modules/auth/entities/user.entity';
-import { RequiresPlan } from '@/modules/billing/decorators/requires-plan.decorator';
-import { RequiresPlanGuard } from '@/modules/billing/requires-plan.guard';
 import { GrammarService } from './grammar.service';
 import { CheckGrammarRequestDto } from './dto/check-grammar.request.dto';
 import { CheckGrammarResponseDto } from './dto/check-grammar.response.dto';
@@ -33,19 +15,10 @@ export class GrammarController {
   constructor(private readonly grammarService: GrammarService) {}
 
   @Post('check')
-  @UseGuards(RequiresPlanGuard)
-  @RequiresPlan({
-    plans: [UserPlan.PRO, UserPlan.TEAM],
-    feature: 'grammar_check',
-  })
-  @Throttle({ default: { limit: 15, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Check text for grammar, style, and impact issues' })
   @ApiResponse({ status: 200, type: CheckGrammarResponseDto })
-  async check(
-    @GetUser() user: User,
-    @Body() dto: CheckGrammarRequestDto,
-  ): Promise<CheckGrammarResponseDto> {
-    return await this.grammarService.check(dto, user.id);
+  check(@Body() dto: CheckGrammarRequestDto): CheckGrammarResponseDto {
+    return this.grammarService.check(dto);
   }
 }

--- a/src/modules/grammar/grammar.controller.ts
+++ b/src/modules/grammar/grammar.controller.ts
@@ -1,5 +1,17 @@
-import { Controller, Post, Body, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { JwtUserAuthGuard } from '@/modules/auth/guards/jwt-user-auth.guard';
 import { Public } from '@/common/decorators/public.decorator';
 import { GrammarService } from './grammar.service';

--- a/src/modules/grammar/grammar.module.ts
+++ b/src/modules/grammar/grammar.module.ts
@@ -1,11 +1,8 @@
 import { Module } from '@nestjs/common';
 import { GrammarController } from './grammar.controller';
 import { GrammarService } from './grammar.service';
-import { AiModule } from '@/modules/ai/ai.module';
-import { UnleashModule } from '@/modules/unleash/unleash.module';
 
 @Module({
-  imports: [AiModule, UnleashModule],
   controllers: [GrammarController],
   providers: [GrammarService],
   exports: [GrammarService],

--- a/src/modules/grammar/grammar.service.ts
+++ b/src/modules/grammar/grammar.service.ts
@@ -1,11 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { AiUsageFeature } from '@prisma/client';
-import { AiUsageService } from '@/modules/ai/ai-usage.service';
-import { OpenAiProvider } from '@/modules/ai/providers/openai.provider';
-import { UnleashService } from '@/modules/unleash/unleash.service';
-import { AI_LLM_GRAMMAR_FLAG } from '@/modules/ai/ai-feature-flags';
-import { MetricsService } from '@/modules/metrics/metrics.service';
+import { Injectable } from '@nestjs/common';
 import {
   CheckGrammarRequestDto,
   GrammarContext,
@@ -27,16 +20,6 @@ interface ReplacementRule {
 
 @Injectable()
 export class GrammarService {
-  private readonly logger = new Logger(GrammarService.name);
-
-  constructor(
-    private readonly configService: ConfigService,
-    private readonly openAiProvider: OpenAiProvider,
-    private readonly aiUsageService: AiUsageService,
-    private readonly unleashService: UnleashService,
-    private readonly metricsService: MetricsService,
-  ) {}
-
   private readonly weakVerbRules: ReplacementRule[] = [
     {
       pattern: /\bresponsible for\b/gi,
@@ -88,145 +71,24 @@ export class GrammarService {
   private readonly passiveVoicePattern =
     /\b(was|were|been|being|is|are)\s+(\w+ed|written|built|done|made|taken|given|shown|known)\b/gi;
 
-  async check(
-    dto: CheckGrammarRequestDto,
-    userId: string,
-  ): Promise<CheckGrammarResponseDto> {
-    if (this.shouldUseLlm(userId)) {
-      const startedAt = Date.now();
-      let quotaConsumed = false;
-      try {
-        await this.aiUsageService.consumeQuota(
-          userId,
-          AiUsageFeature.GRAMMAR_CHECK,
-        );
-        quotaConsumed = true;
-        const llm = await this.openAiProvider.checkGrammar(
-          dto.text,
-          dto.context,
-        );
-        this.metricsService.recordAiCall({
-          feature: 'grammar_check',
-          provider: 'openai',
-          status: 'success',
-          durationMs: Date.now() - startedAt,
-        });
-        return {
-          issues: llm.issues.map(issue => ({
-            type: this.mapIssueType(issue.type),
-            message: issue.message,
-            suggestion: issue.suggestion,
-            startIndex: issue.startIndex,
-            endIndex: issue.endIndex,
-            severity: this.mapIssueSeverity(issue.severity),
-          })),
-          score: llm.score,
-          summary: llm.summary,
-        };
-      } catch (error) {
-        this.metricsService.recordAiCall({
-          feature: 'grammar_check',
-          provider: 'openai',
-          status: 'error',
-          durationMs: Date.now() - startedAt,
-        });
-
-        if (quotaConsumed) {
-          await this.refundQuotaOnProviderFailure(
-            userId,
-            AiUsageFeature.GRAMMAR_CHECK,
-          );
-        }
-
-        const message = error instanceof Error ? error.message : String(error);
-        this.logger.warn(
-          `OpenAI grammar check failed; falling back to heuristic checker. ${message}`,
-        );
-      }
-    }
-
+  check(dto: CheckGrammarRequestDto): CheckGrammarResponseDto {
     const issues: GrammarIssueDto[] = [];
 
-    // Weak verbs
     for (const rule of this.weakVerbRules) {
       this.findMatches(dto.text, rule, issues);
     }
 
-    // Redundant phrases
     for (const rule of this.redundantPhraseRules) {
       this.findMatches(dto.text, rule, issues);
     }
 
-    // Passive voice
     this.detectPassiveVoice(dto.text, issues);
-
-    // Long sentences
     this.detectLongSentences(dto.text, issues);
 
-    // Calculate score
     const score = this.calculateScore(issues);
-
-    // Generate summary
     const summary = this.generateSummary(issues, score, dto.context);
 
     return { issues, score, summary };
-  }
-
-  private async refundQuotaOnProviderFailure(
-    userId: string,
-    feature: AiUsageFeature,
-  ): Promise<void> {
-    try {
-      await this.aiUsageService.refundQuota(userId, feature);
-    } catch (refundError) {
-      const message =
-        refundError instanceof Error
-          ? refundError.message
-          : String(refundError);
-      this.logger.error(
-        `Failed to refund AI quota for feature=${feature.toLowerCase()}, userId=${userId}: ${message}`,
-      );
-    }
-  }
-
-  private shouldUseLlm(userId: string): boolean {
-    const provider = this.configService
-      .get<string>('AI_PROVIDER', 'builtin')
-      ?.trim()
-      .toLowerCase();
-    if (provider !== 'openai') {
-      return false;
-    }
-
-    if (!this.openAiProvider.isAvailable()) {
-      return false;
-    }
-
-    return this.unleashService.isEnabled(AI_LLM_GRAMMAR_FLAG, { userId });
-  }
-
-  private mapIssueType(
-    value: 'grammar' | 'style' | 'impact',
-  ): GrammarIssueType {
-    if (value === 'grammar') {
-      return GrammarIssueType.GRAMMAR;
-    }
-    if (value === 'impact') {
-      return GrammarIssueType.IMPACT;
-    }
-    return GrammarIssueType.STYLE;
-  }
-
-  private mapIssueSeverity(
-    value: 'error' | 'warning' | 'info',
-  ): GrammarIssueSeverity {
-    if (value === 'error') {
-      return GrammarIssueSeverity.ERROR;
-    }
-    if (value === 'warning') {
-      return GrammarIssueSeverity.WARNING;
-    }
-    return GrammarIssueSeverity.INFO;
   }
 
   private findMatches(

--- a/test/modules/auth/users.service.spec.ts
+++ b/test/modules/auth/users.service.spec.ts
@@ -143,7 +143,9 @@ describe('UsersService', () => {
         updatedAt: new Date(),
       };
 
-      prismaService.user.findUnique.mockResolvedValue(existingPrismaUser as any);
+      prismaService.user.findUnique.mockResolvedValue(
+        existingPrismaUser as any,
+      );
 
       await expect(usersService.create(userEntity)).rejects.toThrow(
         ConflictException,


### PR DESCRIPTION
## Summary

- Remove Stripe billing module (Plan, Subscription, AiUsage, AiAnalysisCache Prisma models)
- Remove metrics and queue modules from AppModule
- Strip plan-gating from AI, ATS, and grammar endpoints (auth-only guards remain)
- Simplify ATS and grammar services to pure rule-based analysis (no OpenAI provider dependency)
- Update README to reflect simplified stack

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `npm run lint` passes (verified locally)
- [ ] Unit tests pass (requires test DB)
- [ ] Verify Swagger docs render correctly at `/api/docs`
- [ ] Confirm ATS `/ats/score` endpoint returns rule-based analysis
- [ ] Confirm grammar `/grammar/check` returns heuristic results