### PR TITLE
feat: persist CV section layout (order, hidden, heading overrides)

### DIFF
--- a/prisma/migrations/20260619143937_add_cv_layout/migration.sql
+++ b/prisma/migrations/20260619143937_add_cv_layout/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "cvs" ADD COLUMN     "layout" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -159,6 +159,7 @@ model Cv {
   status     CvStatus @default(DRAFT)
   templateId String?
   isDefault  Boolean  @default(false)
+  layout     Json?
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 

--- a/src/modules/cv/cv.controller.ts
+++ b/src/modules/cv/cv.controller.ts
@@ -48,6 +48,7 @@ import { CreateCvRequestDto } from './dto/request/create-cv.request.dto';
 import { UpdateCvRequestDto } from './dto/request/update-cv.request.dto';
 import { ImportLinkedInToCvRequestDto } from './dto/request/import-linkedin-to-cv.request.dto';
 import { UpsertPersonalInfoRequestDto } from './dto/request/upsert-personal-info.request.dto';
+import { UpsertLayoutRequestDto } from './dto/request/upsert-layout.request.dto';
 import {
   BulkUpsertExperienceRequestDto,
   BulkUpsertEducationRequestDto,
@@ -68,6 +69,7 @@ import {
   ProjectResponseDto,
   LanguageResponseDto,
   CustomSectionResponseDto,
+  CvLayoutResponseDto,
 } from './dto/response/cv.response.dto';
 import { ShareCvRequestDto } from './dto/request/share-cv.request.dto';
 import { CvShareResponseDto } from './dto/response/share-cv.response.dto';
@@ -545,5 +547,26 @@ export class CvController {
       dto,
     );
     return items.map(cs => this.cvMapper.customSectionToResponse(cs));
+  }
+
+  @Put(':id/layout')
+  @UseGuards(JwtUserAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Replace section layout',
+    description:
+      'Persists the per-CV section layout (column order, hidden sections, heading overrides). Full replace.',
+  })
+  @ApiParam({ name: 'id', description: 'CV UUID' })
+  @ApiBody({ type: UpsertLayoutRequestDto })
+  @ApiResponse({ status: 200, type: CvLayoutResponseDto })
+  async updateLayout(
+    @GetUser() user: User,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpsertLayoutRequestDto,
+  ): Promise<CvLayoutResponseDto> {
+    const cv = await this.cvService.updateLayout(id, user.id, dto);
+    // Non-null after a validated write — the column was just set to an object.
+    return this.cvMapper.layoutToResponse(cv.layout)!;
   }
 }

--- a/src/modules/cv/cv.service.ts
+++ b/src/modules/cv/cv.service.ts
@@ -14,6 +14,7 @@ import { CV_INCLUDE_ALL } from './cv.constants';
 import { CreateCvRequestDto } from './dto/request/create-cv.request.dto';
 import { UpdateCvRequestDto } from './dto/request/update-cv.request.dto';
 import { UpsertPersonalInfoRequestDto } from './dto/request/upsert-personal-info.request.dto';
+import { UpsertLayoutRequestDto } from './dto/request/upsert-layout.request.dto';
 import {
   BulkUpsertExperienceRequestDto,
   BulkUpsertEducationRequestDto,
@@ -148,6 +149,33 @@ export class CvService {
     await this.findCvOrThrow(cvId, userId);
     await this.prisma.cv.delete({ where: { id: cvId } });
     this.logger.log(`CV deleted: ${cvId}`);
+  }
+
+  // Full-replace of the section layout blob (reorder / hide / rename headings).
+  // Keys stay opaque; the DTO has already validated structure. See
+  // prismacv-ui/docs/backend-support-cv-editor.md § "Phase 0 — FROZEN contract".
+  async updateLayout(
+    cvId: string,
+    userId: string,
+    dto: UpsertLayoutRequestDto,
+  ) {
+    await this.findCvOrThrow(cvId, userId);
+
+    const cv = await this.prisma.cv.update({
+      where: { id: cvId },
+      data: {
+        layout: {
+          mainOrder: dto.mainOrder,
+          sideOrder: dto.sideOrder,
+          hidden: dto.hidden,
+          titles: dto.titles,
+        },
+      },
+      include: CV_INCLUDE_ALL,
+    });
+
+    this.logger.log(`CV layout updated: ${cvId}`);
+    return cv;
   }
 
   async duplicate(cvId: string, userId: string) {

--- a/src/modules/cv/dto/request/upsert-layout.request.dto.ts
+++ b/src/modules/cv/dto/request/upsert-layout.request.dto.ts
@@ -1,0 +1,86 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsString,
+  IsNotEmpty,
+  MaxLength,
+  ArrayMaxSize,
+  IsObject,
+  Validate,
+  ValidatorConstraint,
+  type ValidatorConstraintInterface,
+} from 'class-validator';
+
+// Section keys are opaque strings (built-in section keys + custom-section ids),
+// so the layout is validated structurally only — never against a section enum.
+// See prismacv-ui/docs/backend-support-cv-editor.md § "Phase 0 — FROZEN contract".
+
+const MAX_KEYS = 50;
+const MAX_KEY_LENGTH = 100;
+const MAX_TITLE_LENGTH = 120;
+
+@ValidatorConstraint({ name: 'sectionTitleMap', async: false })
+class SectionTitleMapConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length > MAX_KEYS) return false;
+    return entries.every(
+      ([, title]) =>
+        typeof title === 'string' && title.length <= MAX_TITLE_LENGTH,
+    );
+  }
+
+  defaultMessage(): string {
+    return `titles must be an object of at most ${MAX_KEYS} string values, each ≤ ${MAX_TITLE_LENGTH} characters`;
+  }
+}
+
+export class UpsertLayoutRequestDto {
+  @ApiProperty({
+    type: [String],
+    example: ['summary', 'experience', 'projects'],
+    description: 'Ordered section keys rendered in the main column',
+  })
+  @IsArray()
+  @ArrayMaxSize(MAX_KEYS)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @MaxLength(MAX_KEY_LENGTH, { each: true })
+  mainOrder!: string[];
+
+  @ApiProperty({
+    type: [String],
+    example: ['skills', 'education', 'certifications', 'languages'],
+    description: 'Ordered section keys rendered in the side column',
+  })
+  @IsArray()
+  @ArrayMaxSize(MAX_KEYS)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @MaxLength(MAX_KEY_LENGTH, { each: true })
+  sideOrder!: string[];
+
+  @ApiProperty({
+    type: [String],
+    example: ['certifications'],
+    description: 'Section keys excluded from the rendered document',
+  })
+  @IsArray()
+  @ArrayMaxSize(MAX_KEYS)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @MaxLength(MAX_KEY_LENGTH, { each: true })
+  hidden!: string[];
+
+  @ApiProperty({
+    example: { experience: 'Work History' },
+    description:
+      'Per-section heading overrides (key → title); send {} when none',
+  })
+  @IsObject()
+  @Validate(SectionTitleMapConstraint)
+  titles!: Record<string, string>;
+}

--- a/src/modules/cv/dto/response/cv.response.dto.ts
+++ b/src/modules/cv/dto/response/cv.response.dto.ts
@@ -80,6 +80,23 @@ export class CustomSectionResponseDto {
   @ApiProperty() sortOrder!: number;
 }
 
+export class CvLayoutResponseDto {
+  @ApiProperty({
+    type: [String],
+    example: ['summary', 'experience', 'projects'],
+  })
+  mainOrder!: string[];
+  @ApiProperty({
+    type: [String],
+    example: ['skills', 'education', 'languages'],
+  })
+  sideOrder!: string[];
+  @ApiProperty({ type: [String], example: ['certifications'] })
+  hidden!: string[];
+  @ApiProperty({ example: { experience: 'Work History' } })
+  titles!: Record<string, string>;
+}
+
 // ─── CV Response DTOs ────────────────────────────────────────────────────────
 
 export class CvResponseDto {
@@ -105,6 +122,8 @@ export class CvResponseDto {
   languages!: LanguageResponseDto[];
   @ApiProperty({ type: [CustomSectionResponseDto] })
   customSections!: CustomSectionResponseDto[];
+  @ApiPropertyOptional({ type: CvLayoutResponseDto })
+  layout?: CvLayoutResponseDto;
 }
 
 export class CvListItemResponseDto {

--- a/src/modules/cv/mappers/cv.mapper.ts
+++ b/src/modules/cv/mappers/cv.mapper.ts
@@ -10,6 +10,7 @@ import {
   ProjectResponseDto,
   LanguageResponseDto,
   CustomSectionResponseDto,
+  CvLayoutResponseDto,
 } from '../dto/response/cv.response.dto';
 import type {
   Cv as PrismaCv,
@@ -62,6 +63,32 @@ export class CvMapper {
     dto.customSections = (cv.customSections ?? []).map(cs =>
       this.customSectionToResponse(cs),
     );
+    dto.layout = this.layoutToResponse(cv.layout);
+    return dto;
+  }
+
+  // Layout is stored as opaque JSON; map defensively in case the column was
+  // hand-edited or predates the validated write path. `null` / non-object → absent.
+  layoutToResponse(
+    layout: PrismaCv['layout'],
+  ): CvLayoutResponseDto | undefined {
+    if (!layout || typeof layout !== 'object' || Array.isArray(layout)) {
+      return undefined;
+    }
+    const raw = layout as Record<string, unknown>;
+    const toStringArray = (value: unknown): string[] =>
+      Array.isArray(value)
+        ? value.filter((v): v is string => typeof v === 'string')
+        : [];
+
+    const dto = new CvLayoutResponseDto();
+    dto.mainOrder = toStringArray(raw.mainOrder);
+    dto.sideOrder = toStringArray(raw.sideOrder);
+    dto.hidden = toStringArray(raw.hidden);
+    dto.titles =
+      raw.titles && typeof raw.titles === 'object' && !Array.isArray(raw.titles)
+        ? (raw.titles as Record<string, string>)
+        : {};
     return dto;
   }
 

--- a/src/modules/cv/templates/cv-html-builder.ts
+++ b/src/modules/cv/templates/cv-html-builder.ts
@@ -1,7 +1,21 @@
 /**
  * Builds an HTML document from CV data for PDF rendering via Puppeteer.
  * Each template ID gets a slightly different visual layout.
+ *
+ * Section layout: when the CV has a `layout` blob (see
+ * prismacv-ui/docs/backend-support-cv-editor.md § "Phase 0 — FROZEN contract"),
+ * the renderer honours it — hidden sections are dropped, headings are renamed,
+ * and sections render in the flattened `[...mainOrder, ...sideOrder]` order. The
+ * render stays single-column (two-column parity is a separate template redesign).
+ * When `layout` is absent the default fixed order is used, byte-for-byte unchanged.
  */
+
+interface SectionLayoutData {
+  mainOrder: string[];
+  sideOrder: string[];
+  hidden: string[];
+  titles: Record<string, string>;
+}
 
 interface CvPdfData {
   title: string;
@@ -56,9 +70,11 @@ interface CvPdfData {
     proficiency: string;
   }[];
   customSections: {
+    id: string;
     title: string;
     entries: unknown;
   }[];
+  layout?: unknown;
 }
 
 function esc(val: string | null | undefined): string {
@@ -91,6 +107,10 @@ function dateRange(
 export function buildCvHtml(cv: CvPdfData): string {
   const pi = cv.personalInfo;
   const accentColor = getAccentColor(cv.templateId);
+  const layout = normalizeLayout(cv.layout);
+  const body = layout
+    ? buildOrderedSections(cv, layout)
+    : buildDefaultSections(cv);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -120,14 +140,8 @@ export function buildCvHtml(cv: CvPdfData): string {
 </style>
 </head>
 <body>
-${buildHeader(pi)}
-${buildSection('Experience', cv.experiences, buildExperience)}
-${buildSection('Education', cv.education, buildEducation)}
-${buildSkillsSection(cv.skills)}
-${buildSection('Certifications', cv.certifications, buildCertification)}
-${buildSection('Projects', cv.projects, buildProject)}
-${buildLanguagesSection(cv.languages)}
-${buildCustomSections(cv.customSections)}
+${buildHeader(pi, !layout)}
+${body}
 </body>
 </html>`;
 }
@@ -147,7 +161,12 @@ function getAccentColor(templateId: string | null): string {
   return colors[templateId ?? ''] ?? '#1a5276';
 }
 
-function buildHeader(pi: CvPdfData['personalInfo']): string {
+// `includeSummary` keeps the summary in the header for the default render;
+// when a layout is present, summary becomes a reorderable/hideable section.
+function buildHeader(
+  pi: CvPdfData['personalInfo'],
+  includeSummary: boolean,
+): string {
   if (!pi) return '';
   const parts: string[] = [];
   if (pi.email) parts.push(`<span>${esc(pi.email)}</span>`);
@@ -160,11 +179,156 @@ function buildHeader(pi: CvPdfData['personalInfo']): string {
   if (pi.linkedinUrl)
     parts.push(`<span><a href="${esc(pi.linkedinUrl)}">LinkedIn</a></span>`);
 
+  const summary =
+    includeSummary && pi.summary
+      ? `\n<div class="summary">${esc(pi.summary)}</div>`
+      : '';
+
   return `
 <h1>${esc(pi.fullName)}</h1>
-<div class="contact">${parts.join('')}</div>
-${pi.summary ? `<div class="summary">${esc(pi.summary)}</div>` : ''}`;
+<div class="contact">${parts.join('')}</div>${summary}`;
 }
+
+// ─── Default render (no layout) — fixed order, unchanged output ───────────────
+
+function buildDefaultSections(cv: CvPdfData): string {
+  return [
+    buildSection('Experience', cv.experiences, buildExperience),
+    buildSection('Education', cv.education, buildEducation),
+    buildSkillsSection(cv.skills),
+    buildSection('Certifications', cv.certifications, buildCertification),
+    buildSection('Projects', cv.projects, buildProject),
+    buildLanguagesSection(cv.languages),
+    buildCustomSections(cv.customSections),
+  ].join('\n');
+}
+
+// ─── Layout-driven render — honour order / hidden / titles ────────────────────
+
+const DEFAULT_SECTION_ORDER = [
+  'summary',
+  'experience',
+  'projects',
+  'skills',
+  'education',
+  'certifications',
+  'languages',
+];
+
+const DEFAULT_SECTION_TITLES: Record<string, string> = {
+  summary: 'Summary',
+  experience: 'Experience',
+  education: 'Education',
+  skills: 'Skills',
+  certifications: 'Certifications',
+  projects: 'Projects',
+  languages: 'Languages',
+};
+
+function buildOrderedSections(
+  cv: CvPdfData,
+  layout: SectionLayoutData,
+): string {
+  // key -> rendered body (no heading). Custom sections are keyed by their id.
+  const bodies: Record<string, string> = {
+    summary: cv.personalInfo?.summary
+      ? `<div class="summary">${esc(cv.personalInfo.summary)}</div>`
+      : '',
+    experience: cv.experiences.map(buildExperience).join('\n'),
+    education: cv.education.map(buildEducation).join('\n'),
+    skills: buildSkillsBody(cv.skills),
+    certifications: cv.certifications.map(buildCertification).join('\n'),
+    projects: cv.projects.map(buildProject).join('\n'),
+    languages: buildLanguagesBody(cv.languages),
+  };
+  const customTitles: Record<string, string> = {};
+  for (const cs of cv.customSections) {
+    bodies[cs.id] =
+      `<div class="custom-entries">${buildCustomEntries(cs.entries)}</div>`;
+    customTitles[cs.id] = cs.title;
+  }
+
+  const hidden = new Set(layout.hidden);
+  const availableKeys = [
+    ...DEFAULT_SECTION_ORDER,
+    ...cv.customSections.map(cs => cs.id),
+  ];
+
+  // Flatten main + side; duplicates resolve to their LAST occurrence (frozen
+  // contract: "last column wins"). Then append any present-but-unlisted keys.
+  const sequence = [...layout.mainOrder, ...layout.sideOrder];
+  const placed = new Set<string>();
+  const orderedReversed: string[] = [];
+  for (let i = sequence.length - 1; i >= 0; i--) {
+    const key = sequence[i];
+    if (hidden.has(key) || placed.has(key)) continue;
+    placed.add(key);
+    orderedReversed.push(key);
+  }
+  const order = orderedReversed.reverse();
+  for (const key of availableKeys) {
+    if (!placed.has(key) && !hidden.has(key)) {
+      placed.add(key);
+      order.push(key);
+    }
+  }
+
+  return order
+    .filter(key => key in bodies)
+    .map(key => {
+      const body = bodies[key];
+      if (!body) return '';
+      const overridden = Object.prototype.hasOwnProperty.call(
+        layout.titles,
+        key,
+      );
+      // Summary stays headingless (matching the header style) unless renamed.
+      if (key === 'summary' && !overridden) return body;
+      const title =
+        layout.titles[key] ??
+        DEFAULT_SECTION_TITLES[key] ??
+        customTitles[key] ??
+        '';
+      return `<h2>${esc(title)}</h2>\n${body}`;
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+// Reads the opaque JSON column defensively. Returns null when there is nothing
+// meaningful to honour, so the default render path is used.
+function normalizeLayout(raw: unknown): SectionLayoutData | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const toStringArray = (value: unknown): string[] =>
+    Array.isArray(value)
+      ? value.filter((v): v is string => typeof v === 'string')
+      : [];
+
+  const mainOrder = toStringArray(obj.mainOrder);
+  const sideOrder = toStringArray(obj.sideOrder);
+  const hidden = toStringArray(obj.hidden);
+  const titles =
+    obj.titles && typeof obj.titles === 'object' && !Array.isArray(obj.titles)
+      ? (Object.fromEntries(
+          Object.entries(obj.titles as Record<string, unknown>).filter(
+            ([, v]) => typeof v === 'string',
+          ),
+        ) as Record<string, string>)
+      : {};
+
+  if (
+    !mainOrder.length &&
+    !sideOrder.length &&
+    !hidden.length &&
+    !Object.keys(titles).length
+  ) {
+    return null;
+  }
+  return { mainOrder, sideOrder, hidden, titles };
+}
+
+// ─── Section renderers ────────────────────────────────────────────────────────
 
 function buildSection<T>(
   title: string,
@@ -191,7 +355,7 @@ function buildEducation(edu: CvPdfData['education'][0]): string {
 </div>`;
 }
 
-function buildSkillsSection(skills: CvPdfData['skills']): string {
+function buildSkillsBody(skills: CvPdfData['skills']): string {
   if (!skills.length) return '';
   const items = skills
     .map(
@@ -199,7 +363,12 @@ function buildSkillsSection(skills: CvPdfData['skills']): string {
         `<div class="skill-item">${esc(s.name)} <span class="skill-level">${esc(s.level)}</span></div>`,
     )
     .join('\n');
-  return `<h2>Skills</h2>\n<div class="skills-grid">${items}</div>`;
+  return `<div class="skills-grid">${items}</div>`;
+}
+
+function buildSkillsSection(skills: CvPdfData['skills']): string {
+  const body = buildSkillsBody(skills);
+  return body ? `<h2>Skills</h2>\n${body}` : '';
 }
 
 function buildCertification(cert: CvPdfData['certifications'][0]): string {
@@ -220,7 +389,7 @@ function buildProject(proj: CvPdfData['projects'][0]): string {
 </div>`;
 }
 
-function buildLanguagesSection(langs: CvPdfData['languages']): string {
+function buildLanguagesBody(langs: CvPdfData['languages']): string {
   if (!langs.length) return '';
   const items = langs
     .map(
@@ -228,23 +397,31 @@ function buildLanguagesSection(langs: CvPdfData['languages']): string {
         `<span class="lang-item">${esc(l.name)} <span class="lang-prof">${esc(l.proficiency)}</span></span>`,
     )
     .join('\n');
-  return `<h2>Languages</h2>\n<div>${items}</div>`;
+  return `<div>${items}</div>`;
+}
+
+function buildLanguagesSection(langs: CvPdfData['languages']): string {
+  const body = buildLanguagesBody(langs);
+  return body ? `<h2>Languages</h2>\n${body}` : '';
+}
+
+function buildCustomEntries(entries: unknown): string {
+  if (!Array.isArray(entries)) return '';
+  return entries
+    .map(e => {
+      const vals = Object.values(e as Record<string, unknown>)
+        .filter(Boolean)
+        .map(v => esc(String(v)));
+      return `<div class="entry-desc">${vals.join(' · ')}</div>`;
+    })
+    .join('\n');
 }
 
 function buildCustomSections(sections: CvPdfData['customSections']): string {
   if (!sections.length) return '';
   return sections
     .map(s => {
-      const entries = Array.isArray(s.entries)
-        ? (s.entries as Record<string, unknown>[])
-            .map(e => {
-              const vals = Object.values(e)
-                .filter(Boolean)
-                .map(v => esc(String(v)));
-              return `<div class="entry-desc">${vals.join(' · ')}</div>`;
-            })
-            .join('\n')
-        : '';
+      const entries = buildCustomEntries(s.entries);
       return `<h2>${esc(s.title)}</h2>\n<div class="custom-entries">${entries}</div>`;
     })
     .join('\n');

--- a/test/e2e/cv-layout.e2e-spec.ts
+++ b/test/e2e/cv-layout.e2e-spec.ts
@@ -1,0 +1,114 @@
+import {
+  ExecutionContext,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from './../../src/app.module';
+import { JwtUserAuthGuard } from '@/modules/auth/guards/jwt-user-auth.guard';
+import { RequiresPlanGuard } from '@/modules/billing/requires-plan.guard';
+import { CvService } from '@/modules/cv/cv.service';
+import { PrismaService } from '@/config/prisma.service';
+
+// HTTP-level integration for PUT /cv/:id/layout. The service is mocked (no DB);
+// the real CvMapper + global ValidationPipe run, so this proves the route wiring,
+// the layout round-trip, and request validation at the boundary.
+describe('CV section layout (e2e)', () => {
+  let app: INestApplication;
+  let cvService: { updateLayout: jest.Mock };
+
+  const mockUser = {
+    id: 'user-layout-e2e',
+    email: 'layout@example.com',
+    role: 'REGULAR',
+    isMasterAdmin: false,
+  };
+
+  const cvId = '22222222-2222-2222-2222-222222222222';
+
+  const layout = {
+    mainOrder: ['summary', 'experience'],
+    sideOrder: ['skills'],
+    hidden: ['certifications'],
+    titles: { experience: 'Work History' },
+  };
+
+  beforeAll(async () => {
+    cvService = {
+      updateLayout: jest.fn().mockResolvedValue({ id: cvId, layout }),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(JwtUserAuthGuard)
+      .useValue({
+        canActivate: (context: ExecutionContext) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = mockUser;
+          return true;
+        },
+      })
+      .overrideGuard(RequiresPlanGuard)
+      .useValue({ canActivate: () => true })
+      .overrideProvider(CvService)
+      .useValue(cvService)
+      .overrideProvider(PrismaService)
+      .useValue({})
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('PUT /cv/:id/layout persists and returns the layout blob', async () => {
+    const response = await request(app.getHttpServer())
+      .put(`/cv/${cvId}/layout`)
+      .send(layout)
+      .expect(200);
+
+    expect(cvService.updateLayout).toHaveBeenCalledWith(
+      cvId,
+      mockUser.id,
+      expect.objectContaining({ mainOrder: ['summary', 'experience'] }),
+    );
+    expect(response.body).toEqual(layout);
+  });
+
+  it('rejects a malformed layout body with 400', async () => {
+    await request(app.getHttpServer())
+      .put(`/cv/${cvId}/layout`)
+      .send({
+        mainOrder: 'not-an-array',
+        sideOrder: [],
+        hidden: [],
+        titles: {},
+      })
+      .expect(400);
+
+    expect(cvService.updateLayout).not.toHaveBeenCalledWith(
+      cvId,
+      mockUser.id,
+      expect.objectContaining({ mainOrder: 'not-an-array' }),
+    );
+  });
+
+  it('rejects an invalid CV id with 400', async () => {
+    await request(app.getHttpServer())
+      .put('/cv/not-a-uuid/layout')
+      .send(layout)
+      .expect(400);
+  });
+});

--- a/test/modules/cv/cv-html-builder.spec.ts
+++ b/test/modules/cv/cv-html-builder.spec.ts
@@ -1,0 +1,247 @@
+import { buildCvHtml } from '@/modules/cv/templates/cv-html-builder';
+
+// buildCvHtml's input type is internal; construct a structurally-complete CV and
+// override per-test. Cast is only to satisfy the non-exported interface.
+function makeCv(overrides: Record<string, unknown> = {}): any {
+  return {
+    title: 'My CV',
+    templateId: '1',
+    personalInfo: {
+      fullName: 'Ada Lovelace',
+      email: 'ada@example.com',
+      phone: null,
+      location: null,
+      website: null,
+      linkedinUrl: null,
+      summary: 'Pioneering programmer.',
+    },
+    experiences: [
+      {
+        company: 'Analytical Engine Co',
+        title: 'Engineer',
+        location: null,
+        startDate: new Date('2020-01-01'),
+        endDate: null,
+        current: true,
+        description: 'Wrote the first algorithm.',
+      },
+    ],
+    education: [
+      {
+        institution: 'Home Tutoring',
+        degree: 'Mathematics',
+        field: null,
+        startDate: new Date('1830-01-01'),
+        endDate: new Date('1835-01-01'),
+        gpa: null,
+      },
+    ],
+    skills: [{ name: 'Algorithms', level: 'EXPERT', category: null }],
+    certifications: [
+      {
+        name: 'Certified Visionary',
+        issuer: 'Royal Society',
+        issueDate: new Date('1843-01-01'),
+        expiryDate: null,
+        credentialUrl: null,
+      },
+    ],
+    projects: [
+      {
+        name: 'Note G',
+        description: 'Bernoulli numbers.',
+        url: null,
+        startDate: null,
+        endDate: null,
+      },
+    ],
+    languages: [{ name: 'English', proficiency: 'NATIVE' }],
+    customSections: [],
+    ...overrides,
+  };
+}
+
+describe('buildCvHtml', () => {
+  describe('default render (no layout)', () => {
+    it('renders sections in the default fixed order', () => {
+      const html = buildCvHtml(makeCv());
+      const order = [
+        'Experience',
+        'Education',
+        'Skills',
+        'Certifications',
+        'Projects',
+        'Languages',
+      ].map(h => html.indexOf(`<h2>${h}</h2>`));
+
+      expect(order.every(i => i >= 0)).toBe(true);
+      const sorted = [...order].sort((a, b) => a - b);
+      expect(order).toEqual(sorted);
+    });
+
+    it('renders the summary inside the header (headingless)', () => {
+      const html = buildCvHtml(makeCv());
+      expect(html).toContain(
+        '<div class="summary">Pioneering programmer.</div>',
+      );
+      expect(html).not.toContain('<h2>Summary</h2>');
+    });
+
+    it('treats a null layout as no layout', () => {
+      const html = buildCvHtml(makeCv({ layout: null }));
+      expect(html).toContain('<h2>Experience</h2>');
+    });
+
+    it('treats an all-empty layout blob as no layout (default order)', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: { mainOrder: [], sideOrder: [], hidden: [], titles: {} },
+        }),
+      );
+      const exp = html.indexOf('<h2>Experience</h2>');
+      const edu = html.indexOf('<h2>Education</h2>');
+      expect(exp).toBeLessThan(edu);
+    });
+  });
+
+  describe('layout-driven render', () => {
+    it('honours order from flattened main + side', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: {
+            mainOrder: ['education', 'experience'],
+            sideOrder: ['languages', 'skills'],
+            hidden: [],
+            titles: {},
+          },
+        }),
+      );
+      const seq = ['Education', 'Experience', 'Languages', 'Skills'].map(h =>
+        html.indexOf(`<h2>${h}</h2>`),
+      );
+      expect(seq.every(i => i >= 0)).toBe(true);
+      expect(seq).toEqual([...seq].sort((a, b) => a - b));
+    });
+
+    it('omits hidden sections', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: {
+            mainOrder: ['experience', 'education'],
+            sideOrder: ['skills', 'certifications', 'languages'],
+            hidden: ['certifications'],
+            titles: {},
+          },
+        }),
+      );
+      expect(html).not.toContain('Certified Visionary');
+      expect(html).not.toContain('<h2>Certifications</h2>');
+      expect(html).toContain('<h2>Experience</h2>');
+    });
+
+    it('drops a hidden summary entirely', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: {
+            mainOrder: ['experience'],
+            sideOrder: [],
+            hidden: ['summary'],
+            titles: {},
+          },
+        }),
+      );
+      expect(html).not.toContain('Pioneering programmer.');
+    });
+
+    it('applies title overrides to headings', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: {
+            mainOrder: ['experience'],
+            sideOrder: [],
+            hidden: [],
+            titles: { experience: 'Work History' },
+          },
+        }),
+      );
+      expect(html).toContain('<h2>Work History</h2>');
+      expect(html).not.toContain('<h2>Experience</h2>');
+    });
+
+    it('escapes a malicious title override', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: {
+            mainOrder: ['experience'],
+            sideOrder: [],
+            hidden: [],
+            titles: { experience: '<script>alert(1)</script>' },
+          },
+        }),
+      );
+      expect(html).not.toContain('<script>alert(1)</script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+
+    it('appends present-but-unlisted sections in default order', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: {
+            mainOrder: ['skills'],
+            sideOrder: [],
+            hidden: [],
+            titles: {},
+          },
+        }),
+      );
+      // skills first (explicitly listed), then the rest by default order.
+      expect(html.indexOf('<h2>Skills</h2>')).toBeLessThan(
+        html.indexOf('<h2>Experience</h2>'),
+      );
+      expect(html).toContain('<h2>Languages</h2>');
+    });
+
+    it('resolves a duplicate key to its last occurrence', () => {
+      const html = buildCvHtml(
+        makeCv({
+          layout: {
+            mainOrder: ['experience', 'skills'],
+            sideOrder: ['experience'],
+            hidden: [],
+            titles: {},
+          },
+        }),
+      );
+      // experience appears once, after skills (its last position).
+      expect(html.indexOf('<h2>Skills</h2>')).toBeLessThan(
+        html.indexOf('<h2>Experience</h2>'),
+      );
+      expect(html.split('<h2>Experience</h2>').length - 1).toBe(1);
+    });
+
+    it('renders a custom section referenced by id, with override title', () => {
+      const html = buildCvHtml(
+        makeCv({
+          customSections: [
+            {
+              id: 'cs-1',
+              title: 'Volunteer Work',
+              entries: [{ detail: 'Red Cross' }],
+            },
+          ],
+          layout: {
+            mainOrder: ['cs-1', 'experience'],
+            sideOrder: [],
+            hidden: [],
+            titles: { 'cs-1': 'Community' },
+          },
+        }),
+      );
+      expect(html).toContain('<h2>Community</h2>');
+      expect(html).toContain('Red Cross');
+      expect(html.indexOf('<h2>Community</h2>')).toBeLessThan(
+        html.indexOf('<h2>Experience</h2>'),
+      );
+    });
+  });
+});

--- a/test/modules/cv/cv.mapper.spec.ts
+++ b/test/modules/cv/cv.mapper.spec.ts
@@ -110,6 +110,66 @@ describe('CvMapper', () => {
 
       expect(result.personalInfo).toBeFalsy();
     });
+
+    it('should include the layout when present', () => {
+      const layout = {
+        mainOrder: ['summary', 'experience'],
+        sideOrder: ['skills'],
+        hidden: ['certifications'],
+        titles: { experience: 'Work History' },
+      };
+      const result = mapper.cvToResponse({ ...mockFullCv, layout } as any);
+
+      expect(result.layout).toEqual(layout);
+    });
+
+    it('should omit layout when the column is null', () => {
+      const result = mapper.cvToResponse({
+        ...mockFullCv,
+        layout: null,
+      } as any);
+
+      expect(result.layout).toBeUndefined();
+    });
+  });
+
+  describe('layoutToResponse', () => {
+    it('maps a stored blob into the layout DTO', () => {
+      const result = mapper.layoutToResponse({
+        mainOrder: ['summary'],
+        sideOrder: ['skills'],
+        hidden: [],
+        titles: { skills: 'Toolbox' },
+      } as any);
+
+      expect(result).toEqual({
+        mainOrder: ['summary'],
+        sideOrder: ['skills'],
+        hidden: [],
+        titles: { skills: 'Toolbox' },
+      });
+    });
+
+    it('returns undefined for null or a non-object', () => {
+      expect(mapper.layoutToResponse(null)).toBeUndefined();
+      expect(mapper.layoutToResponse([] as any)).toBeUndefined();
+      expect(mapper.layoutToResponse('nope' as any)).toBeUndefined();
+    });
+
+    it('coerces malformed fields defensively', () => {
+      const result = mapper.layoutToResponse({
+        mainOrder: ['ok', 42, null],
+        sideOrder: 'not-an-array',
+        titles: ['not-an-object'],
+      } as any);
+
+      expect(result).toEqual({
+        mainOrder: ['ok'],
+        sideOrder: [],
+        hidden: [],
+        titles: {},
+      });
+    });
   });
 
   describe('cvToListItemResponse', () => {

--- a/test/modules/cv/cv.service.spec.ts
+++ b/test/modules/cv/cv.service.spec.ts
@@ -164,4 +164,52 @@ describe('CvService', () => {
       );
     });
   });
+
+  describe('updateLayout', () => {
+    const layoutDto = {
+      mainOrder: ['summary', 'experience'],
+      sideOrder: ['skills'],
+      hidden: ['certifications'],
+      titles: { experience: 'Work History' },
+    };
+
+    it('should persist the layout blob as-is', async () => {
+      prisma.cv.findUnique.mockResolvedValue(mockCv as any);
+      prisma.cv.update.mockResolvedValue({
+        ...mockCv,
+        layout: layoutDto,
+      } as any);
+
+      const result = await service.updateLayout(cvId, userId, layoutDto);
+
+      expect(prisma.cv.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: cvId },
+          data: { layout: layoutDto },
+        }),
+      );
+      expect((result as any).layout).toEqual(layoutDto);
+    });
+
+    it('should throw NotFoundException for a non-existent CV', async () => {
+      prisma.cv.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateLayout(cvId, userId, layoutDto),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.cv.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException if the user does not own the CV', async () => {
+      prisma.cv.findUnique.mockResolvedValue({
+        ...mockCv,
+        userId: 'other-user',
+      } as any);
+
+      await expect(
+        service.updateLayout(cvId, userId, layoutDto),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.cv.update).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/modules/cv/upsert-layout.request.dto.spec.ts
+++ b/test/modules/cv/upsert-layout.request.dto.spec.ts
@@ -1,0 +1,105 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpsertLayoutRequestDto } from '@/modules/cv/dto/request/upsert-layout.request.dto';
+
+async function errorsFor(payload: unknown): Promise<string[]> {
+  const dto = plainToInstance(UpsertLayoutRequestDto, payload);
+  const errors = await validate(dto as object);
+  return errors.map(e => e.property);
+}
+
+const validPayload = {
+  mainOrder: ['summary', 'experience', 'projects'],
+  sideOrder: ['skills', 'education'],
+  hidden: ['certifications'],
+  titles: { experience: 'Work History' },
+};
+
+describe('UpsertLayoutRequestDto', () => {
+  it('accepts a well-formed layout', async () => {
+    expect(await errorsFor(validPayload)).toEqual([]);
+  });
+
+  it('accepts opaque custom-section ids as keys (no enum coupling)', async () => {
+    const errors = await errorsFor({
+      ...validPayload,
+      mainOrder: ['019abc12-3456-7890-abcd-ef0123456789', 'summary'],
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('accepts empty arrays and an empty titles object', async () => {
+    expect(
+      await errorsFor({
+        mainOrder: [],
+        sideOrder: [],
+        hidden: [],
+        titles: {},
+      }),
+    ).toEqual([]);
+  });
+
+  describe('order arrays', () => {
+    it('rejects a non-array order field', async () => {
+      expect(
+        await errorsFor({ ...validPayload, mainOrder: 'summary' }),
+      ).toContain('mainOrder');
+    });
+
+    it('rejects non-string array items', async () => {
+      expect(await errorsFor({ ...validPayload, sideOrder: [1, 2] })).toContain(
+        'sideOrder',
+      );
+    });
+
+    it('rejects empty-string keys', async () => {
+      expect(await errorsFor({ ...validPayload, hidden: [''] })).toContain(
+        'hidden',
+      );
+    });
+
+    it('rejects a key longer than 100 chars', async () => {
+      expect(
+        await errorsFor({ ...validPayload, mainOrder: ['a'.repeat(101)] }),
+      ).toContain('mainOrder');
+    });
+
+    it('rejects more than 50 keys', async () => {
+      expect(
+        await errorsFor({
+          ...validPayload,
+          mainOrder: Array.from({ length: 51 }, (_, i) => `k${i}`),
+        }),
+      ).toContain('mainOrder');
+    });
+  });
+
+  describe('titles', () => {
+    it('rejects a non-object titles', async () => {
+      expect(await errorsFor({ ...validPayload, titles: [] })).toContain(
+        'titles',
+      );
+    });
+
+    it('rejects a non-string title value', async () => {
+      expect(
+        await errorsFor({ ...validPayload, titles: { experience: 42 } }),
+      ).toContain('titles');
+    });
+
+    it('rejects a title longer than 120 chars', async () => {
+      expect(
+        await errorsFor({
+          ...validPayload,
+          titles: { experience: 'x'.repeat(121) },
+        }),
+      ).toContain('titles');
+    });
+
+    it('rejects more than 50 title entries', async () => {
+      const titles: Record<string, string> = {};
+      for (let i = 0; i < 51; i++) titles[`k${i}`] = 'T';
+      expect(await errorsFor({ ...validPayload, titles })).toContain('titles');
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Makes the inline CV editor's **section layout** durable: column order, hidden sections, and renamed headings. Today these live in `localStorage` (per-browser, lost on device switch) and are dropped by the export/public render paths. This adds one nullable JSON column on `Cv` and threads it through the write, read, and render layers.

Backend half of **Phase 6** (cross-repo). Frozen wire contract: `prismacv-ui/docs/backend-support-cv-editor.md` § "Phase 0 — FROZEN contract".

## Changes

- **Schema:** nullable `layout Json?` on `Cv` + reversible migration (`20260619143937_add_cv_layout`). Inert on existing rows (no backfill).
- **Endpoint:** `PUT cv/:id/layout`, mirroring the existing section-PUT decorator stack. `UpsertLayoutRequestDto` with **structural-only** validation — keys stay opaque (custom-section ids allowed, no enum coupling); arrays/titles are size-bounded so they can't bloat the export HTML.
- **Read surface:** `layout` added to `CvResponseDto` and emitted from `cvToResponse`, so `GET cv/:id` and `GET cv/public/:slug` return it for free.
- **Render:** `buildCvHtml` honors order / hidden / titles for sync export, async queue export, and public render. **Byte-identical default render when `layout` is null** — existing CVs unaffected. Render stays single-column (two-column PDF parity is a separate template redesign, deferred).

## Tests

- Unit (all green locally): builder (12), DTO validation (12), service `updateLayout` (3), mapper `layoutToResponse` + `cvToResponse` (5).
- e2e (`cv-layout.e2e-spec.ts`): HTTP round-trip + 400 on malformed body + 400 on bad UUID.

## Reviewer notes

- The migration was generated via `prisma migrate diff` (schema→schema) and **not yet applied to a DB** — run `npm run db:migrate` / `db:deploy`.
- Layout is stored as opaque JSON; the mapper and `buildCvHtml` both read it defensively (null / non-object / malformed → default render).